### PR TITLE
Fignode

### DIFF
--- a/converter/artboard.py
+++ b/converter/artboard.py
@@ -16,10 +16,10 @@ def convert(figma_frame):
         "frame": {
             "_class": "rect",
             "constrainProportions": False,
-            "height": figma_frame['height'],
-            "width": figma_frame['width'],
-            "x": figma_frame['relativeTransform'][0][2],
-            "y": figma_frame['relativeTransform'][1][2]
+            "height": figma_frame.size['y'],
+            "width": figma_frame.size['x'],
+            "x": figma_frame.x,
+            "y": figma_frame.y
         },
         "isFixedToViewport": False,
         "isFlippedHorizontal": False,
@@ -31,7 +31,7 @@ def convert(figma_frame):
         "nameIsFixed": False,
         "resizingConstraint": 9,
         "resizingType": 0,
-        "rotation": figma_frame['rotation'],
+        "rotation": figma_frame.rotation,
         "shouldBreakMaskChain": True,
         "style": {
             "_class": "style",

--- a/converter/group.py
+++ b/converter/group.py
@@ -18,8 +18,8 @@ def convert(figma_group):
         "frame": {
             "_class": "rect",
             "constrainProportions": False,
-            "height": figma_group['height'],
-            "width": figma_group['width'],
+            "height": figma_group.size['y'],
+            "width": figma_group.size['x'],
             "x": coordinates[0],
             "y": coordinates[1]
         },
@@ -33,7 +33,7 @@ def convert(figma_group):
         "nameIsFixed": False,
         "resizingConstraint": 9,
         "resizingType": 0,
-        "rotation": figma_group['rotation'],
+        "rotation": figma_group.rotation,
         "shouldBreakMaskChain": True,
         "style": {
             "_class": "style",

--- a/converter/oval.py
+++ b/converter/oval.py
@@ -19,8 +19,8 @@ def convert(figma_ellipse):
         "frame": {
             "_class": "rect",
             "constrainProportions": False,
-            "height": figma_ellipse['height'],
-            "width": figma_ellipse['width'],
+            "height": figma_ellipse.size['y'],
+            "width": figma_ellipse.size['x'],
             "x": coordinates[0],
             "y": coordinates[1]
         },
@@ -34,7 +34,7 @@ def convert(figma_ellipse):
         "nameIsFixed": False,
         "resizingConstraint": 63,
         "resizingType": 0,
-        "rotation": figma_ellipse['rotation'],
+        "rotation": figma_ellipse.rotation,
         "shouldBreakMaskChain": False,
         "style": style.convert(figma_ellipse),
         "edited": False,

--- a/converter/rectangle.py
+++ b/converter/rectangle.py
@@ -19,8 +19,8 @@ def convert(rect):
         "frame": {
             "_class": "rect",
             "constrainProportions": False,
-            "height": rect['height'],
-            "width": rect['width'],
+            "height": rect.size['y'],
+            "width": rect.size['x'],
             "x": coordinates[0],
             "y": coordinates[1]
         },
@@ -34,7 +34,7 @@ def convert(rect):
         "nameIsFixed": False,
         "resizingConstraint": 9,
         "resizingType": 0,
-        "rotation": rect['rotation'],
+        "rotation": rect.rotation,
         "shouldBreakMaskChain": False,
         "style": style.convert(rect),
         "edited": False,

--- a/converter/style.py
+++ b/converter/style.py
@@ -31,7 +31,7 @@ def convert(figma):
                 "gradientType": 1,
                 "stops": []
             }
-        } for f in figma['fills']
+        } for f in figma['fillPaints']
     ]
     borders = [
         {
@@ -61,7 +61,7 @@ def convert(figma):
                 "gradientType": 1,
                 "stops": []
             }
-        } for b in figma['strokes']
+        } for b in figma['strokePaints']
     ]
 
     return {

--- a/figformat/fig2json.py
+++ b/figformat/fig2json.py
@@ -1,5 +1,6 @@
 import figformat.decodefig as decodefig
 import math
+from .fignode import FigNode
 
 def transform_node(node):
     # Extract ID
@@ -15,26 +16,7 @@ def transform_node(node):
             "position": parent["position"]
         }
 
-    # Transform properties to be more similar to JSON Exporter output
-    node["x"] = node["transform"]["m02"]
-    node["y"] = node["transform"]["m12"]
-    node["relativeTransform"] = [
-        [node["transform"]["m00"], node["transform"]["m01"], node["transform"]["m02"]],
-        [node["transform"]["m10"], node["transform"]["m11"], node["transform"]["m12"]],
-    ]
-    node["rotation"] = math.degrees(
-        math.atan2(-node["transform"]["m10"], node["transform"]["m00"]))
-
-    if "size" in node:
-        node["width"] = node["size"]["x"]
-        node["height"] = node["size"]["y"]
-
-    if "fillPaints" in node:
-        node["fills"] = node["fillPaints"]
-    if "strokePaints" in node:
-        node["strokes"] = node["strokePaints"]
-
-    return node
+    return FigNode(node)
 
 
 def convert_fig(reader):

--- a/figformat/fignode.py
+++ b/figformat/fignode.py
@@ -1,0 +1,24 @@
+import math
+
+class FigNode(dict):
+    @property
+    def x(self):
+        return self['transform']['m02']
+    
+    @property
+    def y(self):
+        return self['transform']['m12']
+    
+    @property
+    def rotation(self):
+        return math.degrees(math.atan2(
+            -self["transform"]["m10"],
+            self["transform"]["m00"]
+        ))
+
+    # Allows node.patata to work the same as node['patata']
+    def __getattribute__(self, name):
+        try:
+            return super().__getattribute__(name)
+        except AttributeError:
+            return self[name]

--- a/utils.py
+++ b/utils.py
@@ -9,13 +9,13 @@ def gen_object_id():
 
 def apply_transform(item):
     #  Calculate relative position
-    relative_position = np.array([item['x'], item['y']])
+    relative_position = np.array([item.x, item.y])
 
     # Vector from rotation center to origin (0,0)
-    vco = np.array([item['width'] / 2, item['height'] / 2])
+    vco = np.array([item.size['x'] / 2, item.size['y'] / 2])
 
     # Rotation matrix
-    theta = np.radians(-item['rotation'])
+    theta = np.radians(-item.rotation)
     c, s = np.cos(theta), np.sin(theta)
     matrix = np.array(((c, -s), (s, c)))
 


### PR DESCRIPTION
Creates a `FigNode` class that adds some helpers to Figma nodes to make our life easier.

It also does a metaprogramming trick (see `__getattribute__`) so we can access all properties as `node.size` instead of `node['size']` to avoid having to memorize which attributes are helpers (`node.rotation`) and which are properties (`node['size`]`).

This basically hacks something that looks like a class on top of a dictionary. We can always convert it to a proper class later if we want to.

Anyway, it's late at night, not sure if this is cool or a piece of 💩, so leaving it as a PR to review tomorrow.