### PR TITLE
🦩 Remove numpy dependency

### DIFF
--- a/converter/shape_path.py
+++ b/converter/shape_path.py
@@ -1,6 +1,5 @@
 from . import base, positioning
 import utils
-import numpy as np
 import itertools
 from sketchformat.layer_group import ShapeGroup, Group
 from sketchformat.layer_shape import ShapePath, CurvePoint, CurveMode
@@ -93,7 +92,7 @@ def convert_shape_path(fig_vector, style, segments, region=0, loop=0):
 
 def convert_line(fig_line):
     # Shift line by half its width
-    vt = np.array([0, -fig_line['strokeWeight'] / 2])
+    vt = [0, -fig_line['strokeWeight'] / 2, 1]
     vtr = positioning.apply_transform(fig_line, vt)
     fig_line['transform'][0][2] += vtr[0]
     fig_line['transform'][1][2] += vtr[1]

--- a/converter/style.py
+++ b/converter/style.py
@@ -1,9 +1,8 @@
 import math
-import numpy as np
-import numpy.typing as npt
 import utils
 from sketchformat.style import *
 from typing import List, TypedDict
+from .positioning import Vector, Matrix
 
 BORDER_POSITION = {
     'CENTER': BorderPosition.CENTER,
@@ -117,7 +116,7 @@ def convert_gradient(fig_node: dict, fig_fill: dict) -> Gradient:
     # Convert positions depending on the gradient type
     mat = fig_fill['transform']
 
-    invmat = np.linalg.inv(mat)
+    invmat = mat.inv()
 
     rotation_offset = 0.0
     if fig_fill['type'] == 'GRADIENT_LINEAR':
@@ -153,8 +152,8 @@ def convert_gradient(fig_node: dict, fig_fill: dict) -> Gradient:
         )
     else:
         # Angular gradients don't allow positioning, but we can at least rotate them
-        rotation_offset = math.atan2(-fig_fill['transform'][1, 0],
-                                     fig_fill['transform'][0, 0]) / 2 / math.pi
+        rotation_offset = math.atan2(-fig_fill['transform'][1][0],
+                                     fig_fill['transform'][0][0]) / 2 / math.pi
 
         return Gradient.Angular(
             stops=convert_stops(fig_fill['stops'], rotation_offset)
@@ -178,10 +177,9 @@ def convert_stops(fig_stops: List[dict], rotation_offset: float = 0.0) -> List[G
     return stops
 
 
-def scaled_distance(a: npt.NDArray[np.float64], b: npt.NDArray[np.float64],
-                    x_scale: float) -> float:
+def scaled_distance(a: Vector, b: Vector, x_scale: float) -> float:
     v = a - b
-    return np.hypot(v[0] * x_scale, v[1])
+    return ((v[0] * x_scale)**2 + v[1]**2)**0.5
 
 
 def rotated_stop(position: float, offset: float) -> float:

--- a/figformat/decodefig.py
+++ b/figformat/decodefig.py
@@ -1,9 +1,9 @@
 import io
-import numpy as np
 import zipfile
 import zlib
 import struct
 from .kiwi import *
+from converter.positioning import Matrix
 
 SUPPORTED_VERSION = 20
 
@@ -36,7 +36,7 @@ def decode(reader):
 
     type_converters = {
         'GUID': lambda x: (x['sessionID'], x['localID']),
-        'Matrix': lambda m: np.array(
+        'Matrix': lambda m: Matrix(
             [[m['m00'], m['m01'], m['m02']], [m['m10'], m['m11'], m['m12']], [0, 0, 1]])
     }
     schema = KiwiSchema(io.BytesIO(segments[0]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy==1.23.3
 Pillow==9.2.0
 fonttools==4.37.3
 appdirs==1.4.4

--- a/sketchformat/layer_shape.py
+++ b/sketchformat/layer_shape.py
@@ -1,9 +1,9 @@
-import numpy as np
 from .layer_common import AbstractStyledLayer
 from .common import Point
 from enum import IntEnum
 from dataclasses import dataclass, field, InitVar
 from typing import List, NamedTuple
+import math
 
 
 class PointRadiusBehaviour(IntEnum):
@@ -143,20 +143,18 @@ class Star(AbstractShapeLayer):
     points: List[CurvePoint] = field(default_factory=list)
 
     def __post_init__(self):
-        for angle in np.arange(
-                -np.pi / 2,
-                2 * np.pi - np.pi / 2,
-                2 * np.pi / self.numberOfPoints):
-            angle2 = angle + np.pi / self.numberOfPoints
+        for i in range(self.numberOfPoints):
+            angle = -math.pi / 2 + 2 * i * math.pi / self.numberOfPoints
+            angle2 = angle + math.pi / self.numberOfPoints
 
             # Outer point
-            x1 = 0.5 + (np.cos(angle) * 0.5)
-            y1 = 0.5 + (np.sin(angle) * 0.5)
+            x1 = 0.5 + (math.cos(angle) * 0.5)
+            y1 = 0.5 + (math.sin(angle) * 0.5)
             self.points.append(CurvePoint.Straight(Point(x1, y1)))
 
             # Inner point shifted by half the angle
-            x2 = 0.5 + (np.cos(angle2) * 0.5 * self.radius)
-            y2 = 0.5 + (np.sin(angle2) * 0.5 * self.radius)
+            x2 = 0.5 + (math.cos(angle2) * 0.5 * self.radius)
+            y2 = 0.5 + (math.sin(angle2) * 0.5 * self.radius)
             self.points.append(CurvePoint.Straight(Point(x2, y2)))
 
 
@@ -168,10 +166,8 @@ class Polygon(AbstractShapeLayer):
     isClosed: bool = True
 
     def __post_init__(self):
-        for angle in np.arange(
-                -np.pi / 2,
-                2 * np.pi - np.pi / 2,
-                2 * np.pi / self.numberOfPoints):
-            x1 = 0.5 + (np.cos(angle) * 0.5)
-            y1 = 0.5 + (np.sin(angle) * 0.5)
+        for i in range(self.numberOfPoints):
+            angle = -math.pi / 2 + 2 * i * math.pi / self.numberOfPoints
+            x1 = 0.5 + (math.cos(angle) * 0.5)
+            y1 = 0.5 + (math.sin(angle) * 0.5)
             self.points.append(CurvePoint.Straight(Point(x1, y1)))

--- a/sketchformat/serialize/orjson.py
+++ b/sketchformat/serialize/orjson.py
@@ -6,7 +6,7 @@ from typing import Optional, IO
 
 
 def serialize(obj: object, file: IO[bytes]) -> None:
-    file.write(orjson.dumps(obj, default=lambda x: x.to_json(), option=orjson.OPT_SERIALIZE_NUMPY))
+    file.write(orjson.dumps(obj, default=lambda x: x.to_json()))
 
 
 # Check if orjson is patched


### PR DESCRIPTION
Saves >10MB in the binary (>20MB in universal builds), which is around 50% of the total. For example, from 24MB to 9.7MB in linux builds.

Seems like a waste to have such a huge dependency just to invert some simple matrices.