### PR TITLE
🏁 Support grids and layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,10 @@ Because of these differences, fig2sketch usually applies two rules when transfor
 
 This kind of transformation will happen with most .fig files, so it won’t show any warnings in the command output.
 
-### Layout grids
-
-Layout grids are not yet supported by this converter. Since it is common to have layout grids enabled, the converter won't show any warning when it finds grids in the .fig file.
-
 ### Text rendering
 
-Text rendering engines between platforms have multiple differences, and it's hard to always guarantee that texts look exactly the same between apps. You may find very sometimes very minor (almost unnoticeable differences). 
-Additionally, there are some other obvious differences between how Sketch and other tools opening .fig files display the data. 
+Text rendering engines between platforms have multiple differences, and it's hard to always guarantee that texts look exactly the same between apps. You may find very sometimes very minor (almost unnoticeable differences).
+Additionally, there are some other obvious differences between how Sketch and other tools opening .fig files display the data.
 One clear difference, for example is about texts with fixed size. In sketch, if a text overflows the size of the layer, the overflowing text won't be visible. You may find that other apps that work with .fig do show the overflowing text when it takes more space than the fixed size of the box.
 
 ## About .sketch documents

--- a/converter/artboard.py
+++ b/converter/artboard.py
@@ -1,8 +1,10 @@
 from . import base, group, prototype, rectangle
 from converter import utils
-from sketchformat.layer_group import Artboard, SimpleGrid
+from sketchformat.layer_group import Artboard, SimpleGrid, LayoutGrid, Rect
 from sketchformat.style import Fill, FillType
 from typing import Optional, List
+import math
+from collections import namedtuple
 
 
 def convert(fig_frame: dict) -> Artboard:
@@ -11,6 +13,8 @@ def convert(fig_frame: dict) -> Artboard:
         **prototype.prototyping_information(fig_frame),
         grid=convert_grid(fig_frame)
     )
+
+    obj.layout = convert_layout(fig_frame, obj.frame)
 
     return obj
 
@@ -82,3 +86,94 @@ def convert_grid(fig_frame: dict) -> Optional[SimpleGrid]:
         thickGridTimes=secondary / primary if secondary else 0,
         isEnabled=True,
     )
+
+
+def convert_layout(fig_frame: dict, frame: Rect) -> Optional[LayoutGrid]:
+    layouts = [g for g in fig_frame.get("layoutGrids", []) if g["pattern"] == "STRIPES"]
+
+    if not layouts:
+        return None
+
+    columns = [l for l in layouts if l["axis"] == "X"]
+    if len(columns) > 1:
+        utils.log_conversion_warning("GRD004", fig_frame)
+
+    col_config = {}
+    width = frame.width
+    if columns:
+        sizes = calculate_layout(columns[0], frame.width)
+
+        col_config = {
+            "columnWidth": sizes.item_size,
+            "gutterWidth": columns[0]["gutterSize"],
+            "numberOfColumns": sizes.item_count,
+            "totalWidth": sizes.size,
+            "drawVertical": True,
+            "horizontalOffset": sizes.offset,
+        }
+
+    rows = [l for l in layouts if l["axis"] == "Y"]
+    if len(rows) > 1:
+        utils.log_conversion_warning("GRD004", fig_frame)
+
+    row_config = {}
+    if rows:
+        gutter_size = rows[0]["gutterSize"]
+        sizes = calculate_layout(rows[0], frame.height)
+
+        if sizes.size != frame.height:
+            utils.log_conversion_warning("GRD005", fig_frame)
+
+        if sizes.offset != 0:
+            utils.log_conversion_warning("GRD006", fig_frame)
+
+        row_scale = sizes.item_size / gutter_size
+        int_row_scale = round(row_scale)
+        if abs(row_scale - int_row_scale) > 0.01:
+            utils.log_conversion_warning("GRD007", fig_frame)
+        else:
+            row_config = {
+                "drawHorizontal": True,
+                "gutterHeight": gutter_size,
+                "rowHeightMultiplication": int_row_scale,
+            }
+
+            if col_config:
+                utils.log_conversion_warning("GRD007", fig_frame)
+            else:
+                row_config["totalWidth"] = frame.width
+
+    if not col_config and not row_config:
+        return None
+
+    return LayoutGrid(**col_config, **row_config)
+
+
+LayoutSizes = namedtuple("LayoutSizes", ["size", "offset", "item_count", "item_size"])
+
+
+def calculate_layout(layout: dict, size: float) -> LayoutSizes:
+    item_num = layout["numSections"]
+    gutter_width = layout["gutterSize"]
+    item_width = layout["sectionSize"]
+    offset = layout["offset"]
+
+    if layout["type"] == "STRETCH":
+        if item_num == 2147483647:
+            item_num = 1
+        total_gutter = (item_num - 1) * gutter_width
+        item_width = (size - total_gutter - 2 * offset) / item_num
+        if item_width < 0:
+            item_width = 0
+        layout_size = size
+    else:
+        if item_num == 2147483647:
+            item_num = math.ceil(size / item_width)
+
+        layout_size = item_width * item_num + gutter_width * (item_num - 1)
+        if layout["type"] == "MAX":
+            offset = size - layout_size
+        elif layout["type"] == "CENTER":
+            offset = (size - layout_size) / 2
+
+    return LayoutSizes(layout_size, offset, item_num, item_width)

--- a/converter/tree.py
+++ b/converter/tree.py
@@ -54,6 +54,9 @@ def convert_node(fig_node: dict, parent_type: str) -> AbstractLayer:
 
     sketch_item = CONVERTERS[type_](fig_node)
 
+    if fig_node.get("layoutGrids", []) and type_ != "ARTBOARD":
+        utils.log_conversion_warning("GRD001", fig_node)
+
     children = []
     for child in fig_node.get("children", []):
         try:

--- a/converter/utils.py
+++ b/converter/utils.py
@@ -59,6 +59,9 @@ WARNING_MESSAGES = {
     "PRT003": "has an action with an unsupported navigation type: {props}. This action will be ignored",
     "PRT004": "has an action with an unsupported connection type: {props}. This action will be ignored",
     "PRT005": "has a prototype with a scroll overflow which is not supported. This setting will be ignored.",
+    "GRD001": "has a layout grid which is only supported in Sketch artboards. It will be ignored",
+    "GRD002": "has multiple grids but their sizes that are not multiples of each other. The larger one will not be converted",
+    "GRD003": "has more than three or more grids and Sketch only supports two. Only the two finer grids will be converted",
 }
 
 

--- a/converter/utils.py
+++ b/converter/utils.py
@@ -62,6 +62,11 @@ WARNING_MESSAGES = {
     "GRD001": "has a layout grid which is only supported in Sketch artboards. It will be ignored",
     "GRD002": "has multiple grids but their sizes that are not multiples of each other. The larger one will not be converted",
     "GRD003": "has more than three or more grids and Sketch only supports two. Only the two finer grids will be converted",
+    "GRD004": "has more than one layouts in the same axis. Only the first one will be converted",
+    "GRD005": "has a row layout with a set height which is not supported by Sketch. It will be converted to a layout grid taking the whole height of the artboard",
+    "GRD006": "has a row layout with an offset that is not supported. The offset will be ignored",
+    "GRD007": "has a row layout with non-integer ratio between gutter and row size. The row layout will not be converted",
+    "GRD008": "has a row and column layout. The rows will only be as wide as the columns (instead of taking the entire width of the artboard)",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 99

--- a/sketchformat/layer_group.py
+++ b/sketchformat/layer_group.py
@@ -83,9 +83,7 @@ class Page(AbstractLayerGroup):
 @dataclass(kw_only=True)
 class ShapeGroup(AbstractLayerGroup):
     _class: str = field(default="shapeGroup")
-    windingRule: WindingRule = (
-        WindingRule.NON_ZERO
-    )  # Legacy, should match style.windingRule
+    windingRule: WindingRule = WindingRule.NON_ZERO  # Legacy, should match style.windingRule
 
 
 @dataclass(kw_only=True)
@@ -105,9 +103,7 @@ class Artboard(AbstractLayerGroup):
     includeBackgroundColorInExport: bool = False
     resizesContent: bool = True
     isFlowHome: bool = False
-    overlayBackgroundInteraction: OverlayBackgroundInteraction = (
-        OverlayBackgroundInteraction.NONE
-    )
+    overlayBackgroundInteraction: OverlayBackgroundInteraction = OverlayBackgroundInteraction.NONE
     presentationStyle: PresentationStyle = PresentationStyle.SCREEN
     overlaySettings: Optional[FlowOverlaySettings] = None
     prototypeViewport: Optional[PrototypeViewport] = None

--- a/sketchformat/layer_group.py
+++ b/sketchformat/layer_group.py
@@ -45,6 +45,7 @@ class LayoutGrid:
     drawHorizontal: bool = False
     drawHorizontalLines: bool = False
     drawVertical: bool = False
+    isEnabled: bool = True
 
 
 @dataclass(kw_only=True)
@@ -82,7 +83,9 @@ class Page(AbstractLayerGroup):
 @dataclass(kw_only=True)
 class ShapeGroup(AbstractLayerGroup):
     _class: str = field(default="shapeGroup")
-    windingRule: WindingRule = WindingRule.NON_ZERO  # Legacy, should match style.windingRule
+    windingRule: WindingRule = (
+        WindingRule.NON_ZERO
+    )  # Legacy, should match style.windingRule
 
 
 @dataclass(kw_only=True)
@@ -102,7 +105,9 @@ class Artboard(AbstractLayerGroup):
     includeBackgroundColorInExport: bool = False
     resizesContent: bool = True
     isFlowHome: bool = False
-    overlayBackgroundInteraction: OverlayBackgroundInteraction = OverlayBackgroundInteraction.NONE
+    overlayBackgroundInteraction: OverlayBackgroundInteraction = (
+        OverlayBackgroundInteraction.NONE
+    )
     presentationStyle: PresentationStyle = PresentationStyle.SCREEN
     overlaySettings: Optional[FlowOverlaySettings] = None
     prototypeViewport: Optional[PrototypeViewport] = None

--- a/tests/converter/test_artboard.py
+++ b/tests/converter/test_artboard.py
@@ -1,5 +1,5 @@
 from .base import *
-from converter import prototype, tree
+from converter import prototype, tree, artboard
 from converter.positioning import Matrix
 from sketchformat.layer_common import ClippingMaskMode
 from sketchformat.style import *
@@ -70,7 +70,9 @@ class TestArtboardBackgroud:
                 "fillPaints": [
                     {
                         "type": "GRADIENT_LINEAR",
-                        "transform": Matrix([[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]),
+                        "transform": Matrix(
+                            [[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]
+                        ),
                         "stops": [
                             {"color": FIG_COLOR[0], "position": 0},
                             {"color": FIG_COLOR[1], "position": 0.4},
@@ -90,3 +92,93 @@ class TestArtboardBackgroud:
         assert bg.style.fills[0].fillType == FillType.GRADIENT
 
         warnings.assert_any_call("ART003", ANY)
+
+
+class TestGrid:
+    def _grid(self, spacing, color):
+        return {
+            "type": "STRETCH",
+            "axis": "X",
+            "visible": True,
+            "numSections": 5,
+            "offset": 0.0,
+            "sectionSize": spacing,
+            "gutterSize": 20.0,
+            "color": color,
+            "pattern": "GRID",
+        }
+
+    def test_single_grid(self):
+        grid = artboard.convert_grid(
+            {**FIG_ARTBOARD, "layoutGrids": [self._grid(20, FIG_COLOR[0])]}
+        )
+
+        assert grid.isEnabled == True
+        assert grid.gridSize == 20
+        assert grid.thickGridTimes == 0
+
+    def test_dual_multiple_grid(self):
+        grid = artboard.convert_grid(
+            {
+                **FIG_ARTBOARD,
+                "layoutGrids": [
+                    self._grid(20, FIG_COLOR[0]),
+                    self._grid(60, FIG_COLOR[0]),
+                ],
+            }
+        )
+
+        assert grid.isEnabled == True
+        assert grid.gridSize == 20
+        assert grid.thickGridTimes == 3
+
+    def test_dual_nonmultiple_grid(self, warnings):
+        grid = artboard.convert_grid(
+            {
+                **FIG_ARTBOARD,
+                "layoutGrids": [
+                    self._grid(15, FIG_COLOR[0]),
+                    self._grid(50, FIG_COLOR[0]),
+                ],
+            }
+        )
+
+        assert grid.isEnabled == True
+        assert grid.gridSize == 15
+        assert grid.thickGridTimes == 0
+
+        warnings.assert_any_call("GRD002", ANY)
+
+    def test_triple_grid(self, warnings):
+        grid = artboard.convert_grid(
+            {
+                **FIG_ARTBOARD,
+                "layoutGrids": [
+                    self._grid(15, FIG_COLOR[0]),
+                    self._grid(30, FIG_COLOR[0]),
+                    self._grid(45, FIG_COLOR[0]),
+                ],
+            }
+        )
+
+        assert grid.isEnabled == True
+        assert grid.gridSize == 15
+        assert grid.thickGridTimes == 2
+
+        warnings.assert_any_call("GRD003", ANY)
+
+    def test_triple_multiple_grid(self):
+        grid = artboard.convert_grid(
+            {
+                **FIG_ARTBOARD,
+                "layoutGrids": [
+                    self._grid(15, FIG_COLOR[0]),
+                    self._grid(25, FIG_COLOR[0]),
+                    self._grid(45, FIG_COLOR[0]),
+                ],
+            }
+        )
+
+        assert grid.isEnabled == True
+        assert grid.gridSize == 15
+        assert grid.thickGridTimes == 3

--- a/tests/converter/test_artboard.py
+++ b/tests/converter/test_artboard.py
@@ -70,9 +70,7 @@ class TestArtboardBackgroud:
                 "fillPaints": [
                     {
                         "type": "GRADIENT_LINEAR",
-                        "transform": Matrix(
-                            [[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]
-                        ),
+                        "transform": Matrix([[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]),
                         "stops": [
                             {"color": FIG_COLOR[0], "position": 0},
                             {"color": FIG_COLOR[1], "position": 0.4},
@@ -185,9 +183,7 @@ class TestGrid:
 
 
 class TestLayout:
-    def _layout(
-        self, axis="X", align="STRETCH", count=4, offset=0, spacing=20, gutter=10
-    ):
+    def _layout(self, axis="X", align="STRETCH", count=4, offset=0, spacing=20, gutter=10):
         return {
             "type": align,
             "axis": axis,


### PR DESCRIPTION
Fixes #18

We cannot support everything, but we are better off with this. Some highlights:

- Sketch only supports grids/layout in artboards, so we ignore the rest.
- Single grids are well supported
- Sketch is limited to two grids and their sizes must be multiple of each other. In case the .fig grids is not compatible with this, we convert the smallest one and ignore the rest.
- Column layouts work ok. We have to do some work to convert the specification (recalculate the number of columns, etc) but work fine in most cases.
- Row layout support in Sketch is very limited, so in many cases we cannot convert it, or do so with poor fidelity:
  - Sketch always uses the whole height of the artboard. If the .fig specifies a fixed height of layout, we ignore it
  - Sketch imposes an integer ratio between gutter and row sizes. If the .fig specifies a non-integer relation we do not convert the layout (it tends to look very bad if we just round it)
- Grid colors are a global (not per-artboard) setting in Sketch, so they are not converted.