### PR TITLE
✋ Support manual position for overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .DS_Store
 .vscode
 version.py
+example/
+output/

--- a/converter/prototype.py
+++ b/converter/prototype.py
@@ -156,7 +156,8 @@ def get_destination_settings_if_any(
 
                 if "overlayBackgroundInteraction" in transition_node:
                     overlay_settings = FlowOverlaySettings.Positioned(
-                        transition_node.get("overlayPositionType", "CENTER")
+                        transition_node.get("overlayPositionType", "CENTER"),
+                        action.get("overlayRelativePosition"),
                     )
 
         case "NONE", _:

--- a/converter/prototype.py
+++ b/converter/prototype.py
@@ -141,7 +141,7 @@ def get_destination_settings_if_any(
     overlay_settings = None
     destination: Optional[str]
 
-    match action["connectionType"], action.get("transitionNodeID"):
+    match action["connectionType"], action.get("transitionNodeID", None):
         case "BACK", _:
             destination = "back"
         case "INTERNAL_NODE", None:

--- a/converter/prototype.py
+++ b/converter/prototype.py
@@ -65,7 +65,6 @@ def convert_flow(fig_node: dict) -> _Flow:
             if action == {}:
                 continue
 
-            # TODO: Back is SCROLL for some reason??? or just irrelevant?
             if action["navigationType"] not in ["NAVIGATE", "SCROLL", "OVERLAY"]:
                 utils.log_conversion_warning("PRT003", fig_node, props=[action["navigationType"]])
                 continue
@@ -142,7 +141,7 @@ def get_destination_settings_if_any(
     overlay_settings = None
     destination: Optional[str]
 
-    match action["connectionType"], action.get("transitionNodeID", None):
+    match action["connectionType"], action.get("transitionNodeID"):
         case "BACK", _:
             destination = "back"
         case "INTERNAL_NODE", None:
@@ -155,9 +154,11 @@ def get_destination_settings_if_any(
                 transition_node = context.fig_node(transition_node_id)
 
                 if "overlayBackgroundInteraction" in transition_node:
+                    offset = action.get("overlayRelativePosition", {"x": 0, "y": 0})
+
                     overlay_settings = FlowOverlaySettings.Positioned(
                         transition_node.get("overlayPositionType", "CENTER"),
-                        action.get("overlayRelativePosition"),
+                        Point.from_dict(offset),
                     )
 
         case "NONE", _:

--- a/sketchformat/common.py
+++ b/sketchformat/common.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Sequence, TypedDict
+from typing import Sequence, TypedDict, Tuple
 
 
 class WindingRule(IntEnum):
@@ -7,12 +7,11 @@ class WindingRule(IntEnum):
     EVEN_ODD = 1
 
 
-class DictXY(TypedDict, total=False):
-    x: float
-    y: float
-
-
 class Point:
+    class _DictXY(TypedDict, total=False):
+        x: float
+        y: float
+
     def __init__(self, x: float, y: float) -> None:
         self.x = x
         self.y = y
@@ -21,11 +20,15 @@ class Point:
         return f"{{{self.x}, {self.y}}}"
 
     @staticmethod
+    def from_tuple(tuple_xy: Tuple[float]) -> "Point":
+        return Point(x=tuple_xy[0], y=tuple_xy[1])
+
+    @staticmethod
     def from_array(array: Sequence[float]) -> "Point":
         return Point(x=array[0], y=array[1])
 
     @staticmethod
-    def from_dict(dict_xy: DictXY) -> "Point":
+    def from_dict(dict_xy: _DictXY) -> "Point":
         return Point(dict_xy["x"], dict_xy["y"])
 
     def __eq__(self, other: object) -> bool:

--- a/sketchformat/common.py
+++ b/sketchformat/common.py
@@ -7,11 +7,12 @@ class WindingRule(IntEnum):
     EVEN_ODD = 1
 
 
-class Point:
-    class _DictXY(TypedDict, total=False):
-        x: float
-        y: float
+class DictXY(TypedDict, total=False):
+    x: float
+    y: float
 
+
+class Point:
     def __init__(self, x: float, y: float) -> None:
         self.x = x
         self.y = y
@@ -24,8 +25,8 @@ class Point:
         return Point(x=array[0], y=array[1])
 
     @staticmethod
-    def from_dict(dict: _DictXY) -> "Point":
-        return Point(dict["x"], dict["y"])
+    def from_dict(dict_xy: DictXY) -> "Point":
+        return Point(dict_xy["x"], dict_xy["y"])
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Point):

--- a/sketchformat/common.py
+++ b/sketchformat/common.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Sequence, TypedDict, Tuple
+from typing import Sequence, TypedDict
 
 
 class WindingRule(IntEnum):
@@ -18,10 +18,6 @@ class Point:
 
     def to_json(self) -> str:
         return f"{{{self.x}, {self.y}}}"
-
-    @staticmethod
-    def from_tuple(tuple_xy: Tuple[float]) -> "Point":
-        return Point(x=tuple_xy[0], y=tuple_xy[1])
 
     @staticmethod
     def from_array(array: Sequence[float]) -> "Point":

--- a/sketchformat/prototype.py
+++ b/sketchformat/prototype.py
@@ -1,7 +1,7 @@
 from .common import Point
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, Dict
 
 
 class OverlayBackgroundInteraction(IntEnum):
@@ -31,8 +31,9 @@ class FlowOverlaySettings:
     overlayType: int = 0
 
     @staticmethod
-    def Positioned(position: str) -> "FlowOverlaySettings":
+    def Positioned(position: str, manual_offset: Dict = None) -> "FlowOverlaySettings":
         anchor = Point(0.5, 0.5)
+        offset = Point.from_dict(manual_offset) if manual_offset is not None else Point(0, 0)
 
         match position:
             case "TOP_LEFT":
@@ -47,8 +48,10 @@ class FlowOverlaySettings:
                 anchor = Point(0.5, 1)
             case "BOTTOM_RIGHT":
                 anchor = Point(1, 1)
+            case "MANUAL":
+                anchor = Point(0, 0)
 
-        return FlowOverlaySettings(overlayAnchor=anchor, sourceAnchor=anchor)
+        return FlowOverlaySettings(overlayAnchor=anchor, sourceAnchor=anchor, offset=offset)
 
     @staticmethod
     def RegularArtboard() -> "FlowOverlaySettings":

--- a/sketchformat/prototype.py
+++ b/sketchformat/prototype.py
@@ -1,7 +1,7 @@
-from .common import Point
+from .common import Point, DictXY
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Optional, Dict
+from typing import Optional
 
 
 class OverlayBackgroundInteraction(IntEnum):
@@ -31,9 +31,9 @@ class FlowOverlaySettings:
     overlayType: int = 0
 
     @staticmethod
-    def Positioned(position: str, manual_offset: Dict = None) -> "FlowOverlaySettings":
+    def Positioned(position: str, manual_offset: Optional[DictXY] = None) -> "FlowOverlaySettings":
         anchor = Point(0.5, 0.5)
-        offset = Point.from_dict(manual_offset) if manual_offset is not None else Point(0, 0)
+        offset = Point(0, 0) if manual_offset is None else Point.from_dict(manual_offset)
 
         match position:
             case "TOP_LEFT":

--- a/sketchformat/prototype.py
+++ b/sketchformat/prototype.py
@@ -1,7 +1,7 @@
 from .common import Point
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Optional, Tuple
+from typing import Optional
 
 
 class OverlayBackgroundInteraction(IntEnum):

--- a/sketchformat/prototype.py
+++ b/sketchformat/prototype.py
@@ -1,7 +1,7 @@
-from .common import Point, DictXY
+from .common import Point
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, Tuple
 
 
 class OverlayBackgroundInteraction(IntEnum):
@@ -31,9 +31,8 @@ class FlowOverlaySettings:
     overlayType: int = 0
 
     @staticmethod
-    def Positioned(position: str, manual_offset: Optional[DictXY] = None) -> "FlowOverlaySettings":
+    def Positioned(position: str, offset: Point = Point(0, 0)) -> "FlowOverlaySettings":
         anchor = Point(0.5, 0.5)
-        offset = Point(0, 0) if manual_offset is None else Point.from_dict(manual_offset)
 
         match position:
             case "TOP_LEFT":


### PR DESCRIPTION
Adds support for overlays without a fixed position, but a manually picked one. In sketch this is translated by keeping a (0, 0) anchor position and setting the offset with the relative coordinates as found in the origin frame.