### PR TITLE
↔ Fix kerning issues

### DIFF
--- a/converter/text.py
+++ b/converter/text.py
@@ -262,6 +262,7 @@ def kerning(fig_text):
     if "letterSpacing" in fig_text:
         match fig_text["letterSpacing"]:
             case {"units": "PIXELS", "value": pixels}:
+                # We handle kerning 0 as Auto (None) to match Sketch behavior better
                 return pixels if pixels != 0 else None
             case {"units": "PERCENT", "value": percent}:
                 return fig_text["fontSize"] * percent / 100

--- a/converter/text.py
+++ b/converter/text.py
@@ -90,6 +90,11 @@ def convert(fig_text):
     if len(obj.attributedString.attributes) > 1:
         obj.style.fills = []
 
+    # Adjust frame's width to include kerning so the text doesn't get cut
+    converted_kerning = obj.style.textStyle.encodedAttributes.kerning
+    if obj.textBehaviour == TextBehaviour.FLEXIBLE_WIDTH and converted_kerning is not None:
+        obj.frame.width += converted_kerning
+
     return obj
 
 
@@ -257,13 +262,13 @@ def kerning(fig_text):
     if "letterSpacing" in fig_text:
         match fig_text["letterSpacing"]:
             case {"units": "PIXELS", "value": pixels}:
-                return pixels
+                return pixels if pixels != 0 else None
             case {"units": "PERCENT", "value": percent}:
                 return fig_text["fontSize"] * percent / 100
             case _:
                 raise Exception(f"Unknown letter spacing unit")
     else:
-        return 0
+        return None
 
 
 def line_height(fig_text):

--- a/tests/converter/test_positioning.py
+++ b/tests/converter/test_positioning.py
@@ -1,30 +1,30 @@
+import pytest
 from converter import positioning
 from converter.errors import Fig2SketchWarning
 from math import nan
-import pytest
 
 
-def test_nan():
-    fig = {
-        "transform": positioning.Matrix([[nan, nan, nan], [nan, nan, nan]]),
-        "size": {"x": 1, "y": 2},
-    }
-    with pytest.raises(Fig2SketchWarning) as e:
-        positioning.convert(fig)
+class TestConvert:
+    def test_nan(self):
+        fig = {
+            "transform": positioning.Matrix([[nan, nan, nan], [nan, nan, nan]]),
+            "size": {"x": 1, "y": 2},
+        }
+        with pytest.raises(Fig2SketchWarning) as e:
+            positioning.convert(fig)
 
-    assert e.value.code == "POS001"
+        assert e.value.code == "POS001"
 
+    def test_0_size(self):
+        """Sketch does not support 0-size layers (it crashes), so it must be converted to 0.1 pt
 
-def test_0_size():
-    """Sketch does not support 0-size layers (it crashes), so it must be converted to 0.1 pt
+        0.1pt is the minimum which currently works (there are checks that round 0.1 to 0)
+        The most common case is a horizontal/vertical line, which this test checks.
+        """
+        fig = {
+            "transform": positioning.Matrix([[1, 0, 90], [0, 1, -50]]),
+            "size": {"x": 50, "y": 0},
+        }
 
-    0.1pt is the minimum which currently works (there are checks that round 0.1 to 0)
-    The most common case is a horizontal/vertical line, which this test checks.
-    """
-    fig = {
-        "transform": positioning.Matrix([[1, 0, 90], [0, 1, -50]]),
-        "size": {"x": 50, "y": 0},
-    }
-
-    pos = positioning.convert(fig)
-    assert pos["frame"].height == 0.1
+        pos = positioning.convert(fig)
+        assert pos["frame"].height == 0.1

--- a/tests/converter/test_rectangle.py
+++ b/tests/converter/test_rectangle.py
@@ -2,7 +2,7 @@ from converter.rectangle import convert
 from .base import FIG_BASE
 
 
-class TestConvert:
+class TestCorners:
     def test_straight_corners(self):
         rect = convert({**FIG_BASE})
         for p in rect.points:

--- a/tests/converter/test_rectangle.py
+++ b/tests/converter/test_rectangle.py
@@ -1,31 +1,29 @@
 from converter.rectangle import convert
-from sketchformat.style import *
 from .base import FIG_BASE
 
 
-def test_straight_corners():
-    rect = convert({**FIG_BASE})
-    for p in rect.points:
-        assert p.cornerRadius == 0
+class TestConvert:
+    def test_straight_corners(self):
+        rect = convert({**FIG_BASE})
+        for p in rect.points:
+            assert p.cornerRadius == 0
 
+    def test_round_corners(self):
+        rect = convert({**FIG_BASE, "cornerRadius": 5, "rectangleCornerRadiiIndependent": False})
+        for p in rect.points:
+            assert p.cornerRadius == 5
 
-def test_round_corners():
-    rect = convert({**FIG_BASE, "cornerRadius": 5, "rectangleCornerRadiiIndependent": False})
-    for p in rect.points:
-        assert p.cornerRadius == 5
-
-
-def test_uneven_corners():
-    rect = convert(
-        {
-            **FIG_BASE,
-            "rectangleTopLeftCornerRadius": 5,
-            "rectangleBottomRightCornerRadius": 7,
-            "fixedRadius": 10,
-            "rectangleCornerRadiiIndependent": True,
-        }
-    )
-    assert rect.points[0].cornerRadius == 5
-    assert rect.points[1].cornerRadius == 0
-    assert rect.points[2].cornerRadius == 7
-    assert rect.points[3].cornerRadius == 0
+    def test_uneven_corners(self):
+        rect = convert(
+            {
+                **FIG_BASE,
+                "rectangleTopLeftCornerRadius": 5,
+                "rectangleBottomRightCornerRadius": 7,
+                "fixedRadius": 10,
+                "rectangleCornerRadiiIndependent": True,
+            }
+        )
+        assert rect.points[0].cornerRadius == 5
+        assert rect.points[1].cornerRadius == 0
+        assert rect.points[2].cornerRadius == 7
+        assert rect.points[3].cornerRadius == 0

--- a/tests/converter/test_style.py
+++ b/tests/converter/test_style.py
@@ -1,5 +1,4 @@
 from converter.style import *
-from sketchformat.style import *
 import dataclasses
 from .base import *
 


### PR DESCRIPTION
This PR fixes 2 issues related to kerning:

- Set auto kerning (basically not including the property) when kerning is null or 0 in fig files
- Adjust text's frame width when text width is flexible and kerning is present (to avoid text cuts in Sketch)