### PR TITLE
🐍 Add accurate python version required in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python fig2sketch.py --salt 12345678 example/shapes_party.fig output/output.sket
 
 ## Install
 
-Before moving forward, you need Python 3 installed in your machine.
+Before moving forward, you need Python 3.10 or newer installed in your machine.
 
 ```
 python -m venv .venv


### PR DESCRIPTION
As stated by [this tweet](https://twitter.com/cedriceberhardt/status/1597696006594105344), we actually require Python's version 3.10  since we use match which is just supported from that version forward.