### PR TITLE
§ Add support for sections

### DIFF
--- a/converter/artboard.py
+++ b/converter/artboard.py
@@ -1,9 +1,9 @@
+import math
 from . import base, group, prototype, rectangle
 from converter import utils
 from sketchformat.layer_group import Artboard, SimpleGrid, LayoutGrid, Rect
 from sketchformat.style import Fill, FillType
-from typing import Optional, List
-import math
+from typing import Optional
 from collections import namedtuple
 
 
@@ -93,7 +93,6 @@ def convert_layout(fig_frame: dict, frame: Rect) -> Optional[LayoutGrid]:
         utils.log_conversion_warning("GRD004", fig_frame)
 
     col_config = {}
-    width = frame.width
     if columns:
         sizes = calculate_layout(columns[0], frame.width)
 

--- a/converter/base.py
+++ b/converter/base.py
@@ -222,12 +222,12 @@ def resizing_constraint(fig_node: dict) -> int:
 
 
 def masking(fig_node: dict) -> _Masking:
-    CLIPPING_MODE = {
+    clipping_mode = {
         "ALPHA": ClippingMaskMode.ALPHA,
         "OUTLINE": ClippingMaskMode.OUTLINE,
     }
     return {
         "shouldBreakMaskChain": False,
         "hasClippingMask": bool(fig_node.get("mask")),
-        "clippingMaskMode": CLIPPING_MODE[fig_node.get("maskType", "OUTLINE")],
+        "clippingMaskMode": clipping_mode[fig_node.get("maskType", "OUTLINE")],
     }

--- a/converter/base.py
+++ b/converter/base.py
@@ -221,13 +221,15 @@ def resizing_constraint(fig_node: dict) -> int:
     return h + v
 
 
+CLIPPING_MODE = {
+    "ALPHA": ClippingMaskMode.ALPHA,
+    "OUTLINE": ClippingMaskMode.OUTLINE,
+}
+
+
 def masking(fig_node: dict) -> _Masking:
-    clipping_mode = {
-        "ALPHA": ClippingMaskMode.ALPHA,
-        "OUTLINE": ClippingMaskMode.OUTLINE,
-    }
     return {
         "shouldBreakMaskChain": False,
         "hasClippingMask": bool(fig_node.get("mask")),
-        "clippingMaskMode": clipping_mode[fig_node.get("maskType", "OUTLINE")],
+        "clippingMaskMode": CLIPPING_MODE[fig_node.get("maskType", "OUTLINE")],
     }

--- a/converter/document.py
+++ b/converter/document.py
@@ -1,7 +1,7 @@
-from converter import utils
 import zipfile
 from . import font
 from .context import context
+from converter import utils
 from sketchformat.layer_group import Page
 from typing import List
 

--- a/converter/font.py
+++ b/converter/font.py
@@ -1,8 +1,8 @@
 import appdirs
 import os
-from converter import utils
 import urllib.request
 import urllib.parse
+from converter import utils
 from fontTools.ttLib import TTFont
 from sketchformat.document import FontReference, JsonFileReference
 from typing import IO, Tuple

--- a/converter/group.py
+++ b/converter/group.py
@@ -18,7 +18,7 @@ def convert(fig_group):
 def post_process_frame(fig_group: dict, sketch_group: Group) -> Group:
     convert_frame_style(fig_group, sketch_group)
 
-    if fig_group["resizeToFit"]:
+    if "resizeToFit" in fig_group and fig_group["resizeToFit"]:
         adjust_group_resizing_constraint(fig_group, sketch_group)
     else:
         # For frames converted to groups, add clipmask, resize children, etc

--- a/converter/group.py
+++ b/converter/group.py
@@ -18,7 +18,7 @@ def convert(fig_group):
 def post_process_frame(fig_group: dict, sketch_group: Group) -> Group:
     convert_frame_style(fig_group, sketch_group)
 
-    if "resizeToFit" in fig_group and fig_group["resizeToFit"]:
+    if fig_group["resizeToFit"]:
         adjust_group_resizing_constraint(fig_group, sketch_group)
     else:
         # For frames converted to groups, add clipmask, resize children, etc

--- a/converter/instance.py
+++ b/converter/instance.py
@@ -1,11 +1,11 @@
 import copy
-from converter import utils
 from . import base, group
 from .context import context
 from .config import config
+from converter import utils
 from sketchformat.layer_group import SymbolInstance, OverrideValue
 from sketchformat.style import Style
-from typing import Optional, List, Tuple
+from typing import List, Tuple
 
 
 def convert(fig_instance):

--- a/converter/page.py
+++ b/converter/page.py
@@ -1,5 +1,5 @@
-from converter import utils
 from . import style, positioning
+from converter import utils
 from sketchformat.layer_group import *
 from sketchformat.layer_shape import Rectangle
 from sketchformat.style import Fill

--- a/converter/positioning.py
+++ b/converter/positioning.py
@@ -1,7 +1,7 @@
 import math
+from .errors import Fig2SketchWarning
 from sketchformat.layer_common import Rect, AbstractLayer
 from typing import TypedDict, Tuple, List, Sequence
-from .errors import Fig2SketchWarning
 
 
 class Vector(list):

--- a/converter/rectangle.py
+++ b/converter/rectangle.py
@@ -1,5 +1,5 @@
-from converter import utils
 from . import base
+from converter import utils
 from sketchformat.layer_common import Rect, ClippingMaskMode
 from sketchformat.layer_shape import Rectangle
 from sketchformat.style import Style

--- a/converter/shape_path.py
+++ b/converter/shape_path.py
@@ -1,13 +1,13 @@
 from . import base, positioning
-from converter import utils
+import copy
 import itertools
+from collections import defaultdict
+from converter import utils
 from sketchformat.layer_group import ShapeGroup, Group
 from sketchformat.layer_shape import ShapePath, CurvePoint, CurveMode
 from sketchformat.common import WindingRule, Point
 from sketchformat.style import MarkerType
-from collections import defaultdict
-import copy
-from typing import Union, List, TypedDict, Tuple, Dict, Any
+from typing import Union, List, TypedDict, Tuple, Dict
 
 STROKE_CAP_TO_MARKER_TYPE = {
     "NONE": MarkerType.NONE,

--- a/converter/style.py
+++ b/converter/style.py
@@ -1,9 +1,9 @@
+import dataclasses
 import math
+from .positioning import Vector, Matrix
 from converter import utils
 from sketchformat.style import *
 from typing import List, TypedDict
-from .positioning import Vector, Matrix
-import dataclasses
 
 BORDER_POSITION = {
     "CENTER": BorderPosition.CENTER,

--- a/converter/symbol.py
+++ b/converter/symbol.py
@@ -1,6 +1,6 @@
-from converter import utils
 from . import instance, group, base, prototype
 from .context import context
+from converter import utils
 from sketchformat.layer_group import *
 
 LAYOUT_AXIS = {

--- a/converter/text.py
+++ b/converter/text.py
@@ -1,8 +1,8 @@
 import copy
 import itertools
-from converter import utils
 from . import base, style
 from .context import context
+from converter import utils
 from sketchformat.text import *
 
 AlignVertical = {

--- a/converter/tree.py
+++ b/converter/tree.py
@@ -83,8 +83,10 @@ def get_node_type(fig_node: dict, parent_type: str) -> str:
     # We do this because Sketch does not support nested artboards
     # If a Frame is detected inside another Frame, the internal one
     # is considered a group
-    if fig_node["type"] == "FRAME":
-        if parent_type == "CANVAS" and not fig_node["resizeToFit"]:
+    if fig_node["type"] == "FRAME" or fig_node["type"] == "SECTION":
+        if parent_type == "CANVAS" and (
+            "resizeToFit" not in fig_node or not fig_node["resizeToFit"]
+        ):
             return "ARTBOARD"
         else:
             return "GROUP"

--- a/converter/tree.py
+++ b/converter/tree.py
@@ -83,10 +83,8 @@ def get_node_type(fig_node: dict, parent_type: str) -> str:
     # We do this because Sketch does not support nested artboards
     # If a Frame is detected inside another Frame, the internal one
     # is considered a group
-    if fig_node["type"] == "FRAME" or fig_node["type"] == "SECTION":
-        if parent_type == "CANVAS" and (
-            "resizeToFit" not in fig_node or not fig_node["resizeToFit"]
-        ):
+    if fig_node["type"] in ["FRAME", "SECTION"]:
+        if parent_type == "CANVAS" and not fig_node["resizeToFit"]:
             return "ARTBOARD"
         else:
             return "GROUP"

--- a/converter/utils.py
+++ b/converter/utils.py
@@ -71,7 +71,7 @@ WARNING_MESSAGES = {
     "SYM003": "overrides unsupported properties: {props}. The instance will be detached",
     "ART001": "has at least one corner radius which is not supported by sketch artboards. The corner radius will be ignored",
     "ART002": "is being converted to an artboard. However, artboard rotations are not supported. Rotation will be ignored",
-    "ART003": "has an style that is not supported by sketch artboards. It will add a background rectangle to the artboard with the frame style",
+    "ART003": "has a style that is not supported by sketch artboards. It will add a background rectangle to the artboard with the frame style",
     "GRP001": "has inner shadows which are not supported at group level in Sketch. It will be copied to the layers inside the frame",
     "GRP002": "has children with different resizing constraints. This cannot be accurately represented in Sketch so the converted group will not scale correctly",
     "CMP001": "uses a shared style which could not be found in the document. It will not be applied",

--- a/tests/converter/base.py
+++ b/tests/converter/base.py
@@ -29,6 +29,21 @@ SKETCH_COLOR = [
     Color(red=0, green=0, blue=1, alpha=1),
 ]
 
+FIG_GRADIENT_FILL_PAINTS = {
+    "fillPaints": [
+        {
+            "type": "GRADIENT_LINEAR",
+            "transform": Matrix([[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]),
+            "stops": [
+                {"color": FIG_COLOR[0], "position": 0},
+                {"color": FIG_COLOR[1], "position": 0.4},
+                {"color": FIG_COLOR[2], "position": 1},
+            ],
+            "visible": True,
+        }
+    ],
+}
+
 
 @pytest.fixture
 def warnings(monkeypatch):

--- a/tests/converter/test_artboard.py
+++ b/tests/converter/test_artboard.py
@@ -91,6 +91,7 @@ class TestArtboardBackgroud:
         fig_section = {
             **FIG_BASE,
             "type": "SECTION",
+            "resizeToFit": False,
             "fillPaints": [
                 {
                     "type": "SOLID",

--- a/tests/converter/test_artboard.py
+++ b/tests/converter/test_artboard.py
@@ -1,10 +1,9 @@
+import pytest
 from .base import *
 from converter import prototype, tree, artboard
-from converter.positioning import Matrix
-from sketchformat.layer_common import ClippingMaskMode, Rect
+from sketchformat.layer_common import Rect
 from sketchformat.layer_shape import Rectangle
 from sketchformat.style import *
-import pytest
 from unittest.mock import ANY
 
 FIG_ARTBOARD = {
@@ -25,7 +24,7 @@ class TestArtboardBackgroud:
     def test_no_background(self):
         ab = tree.convert_node(FIG_ARTBOARD, "CANVAS")
 
-        assert ab.hasBackgroundColor == False
+        assert not ab.hasBackgroundColor
 
     def test_disabled_background(self):
         ab = tree.convert_node(
@@ -43,7 +42,7 @@ class TestArtboardBackgroud:
             "CANVAS",
         )
 
-        assert ab.hasBackgroundColor == False
+        assert not ab.hasBackgroundColor
 
     def test_simple_background(self):
         ab = tree.convert_node(
@@ -61,30 +60,16 @@ class TestArtboardBackgroud:
             "CANVAS",
         )
 
-        assert ab.hasBackgroundColor == True
+        assert ab.hasBackgroundColor
         assert ab.backgroundColor == SKETCH_COLOR[0]
 
     def test_gradient_background(self, warnings):
         ab = tree.convert_node(
-            {
-                **FIG_ARTBOARD,
-                "fillPaints": [
-                    {
-                        "type": "GRADIENT_LINEAR",
-                        "transform": Matrix([[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]),
-                        "stops": [
-                            {"color": FIG_COLOR[0], "position": 0},
-                            {"color": FIG_COLOR[1], "position": 0.4},
-                            {"color": FIG_COLOR[2], "position": 1},
-                        ],
-                        "visible": True,
-                    }
-                ],
-            },
+            {**FIG_ARTBOARD, **FIG_GRADIENT_FILL_PAINTS},
             "CANVAS",
         )
 
-        assert ab.hasBackgroundColor == False
+        assert not ab.hasBackgroundColor
         assert len(ab.layers) == 1
         bg = ab.layers[0]
         assert len(bg.style.fills) == 1
@@ -101,6 +86,27 @@ class TestArtboardBackgroud:
         assert isinstance(ab.layers[0], Rectangle)
         assert ab.layers[0].hasClippingMask
         assert ab.layers[0].points[0].cornerRadius == 5
+
+    def test_section_as_artboard(self):
+        fig_section = {
+            **FIG_BASE,
+            "type": "SECTION",
+            "fillPaints": [
+                {
+                    "type": "SOLID",
+                    "color": FIG_COLOR[0],
+                    "opacity": 0.9,
+                    "visible": True,
+                }
+            ],
+            "children": [{**FIG_BASE, "type": "ROUNDED_RECTANGLE"}],
+        }
+
+        ab = tree.convert_node(fig_section, "CANVAS")
+
+        assert ab._class == "artboard"
+        assert ab.hasBackgroundColor
+        assert ab.backgroundColor == SKETCH_COLOR[0]
 
 
 class TestGrid:
@@ -122,7 +128,7 @@ class TestGrid:
             {**FIG_ARTBOARD, "layoutGrids": [self._grid(20, FIG_COLOR[0])]}
         )
 
-        assert grid.isEnabled == True
+        assert grid.isEnabled
         assert grid.gridSize == 20
         assert grid.thickGridTimes == 0
 
@@ -137,7 +143,7 @@ class TestGrid:
             }
         )
 
-        assert grid.isEnabled == True
+        assert grid.isEnabled
         assert grid.gridSize == 20
         assert grid.thickGridTimes == 3
 
@@ -152,7 +158,7 @@ class TestGrid:
             }
         )
 
-        assert grid.isEnabled == True
+        assert grid.isEnabled
         assert grid.gridSize == 15
         assert grid.thickGridTimes == 0
 
@@ -170,7 +176,7 @@ class TestGrid:
             }
         )
 
-        assert grid.isEnabled == True
+        assert grid.isEnabled
         assert grid.gridSize == 15
         assert grid.thickGridTimes == 2
 
@@ -188,7 +194,7 @@ class TestGrid:
             }
         )
 
-        assert grid.isEnabled == True
+        assert grid.isEnabled
         assert grid.gridSize == 15
         assert grid.thickGridTimes == 3
 

--- a/tests/converter/test_base.py
+++ b/tests/converter/test_base.py
@@ -1,9 +1,8 @@
+import pytest
 from .base import *
 from converter import prototype, tree, base
 from converter.positioning import Matrix
-from sketchformat.layer_common import ClippingMaskMode
 from sketchformat.style import *
-import pytest
 from unittest.mock import ANY
 from converter.context import context
 
@@ -66,21 +65,7 @@ class TestArtboardBackgroud:
 
     def test_gradient_background(self, warnings):
         ab = tree.convert_node(
-            {
-                **FIG_ARTBOARD,
-                "fillPaints": [
-                    {
-                        "type": "GRADIENT_LINEAR",
-                        "transform": Matrix([[0.7071, -0.7071, 0.6], [0.7071, 0.7071, -0.1]]),
-                        "stops": [
-                            {"color": FIG_COLOR[0], "position": 0},
-                            {"color": FIG_COLOR[1], "position": 0.4},
-                            {"color": FIG_COLOR[2], "position": 1},
-                        ],
-                        "visible": True,
-                    }
-                ],
-            },
+            {**FIG_ARTBOARD, **FIG_GRADIENT_FILL_PAINTS},
             "CANVAS",
         )
 

--- a/tests/converter/test_group.py
+++ b/tests/converter/test_group.py
@@ -210,6 +210,7 @@ class TestFrameStyles:
         fig_section = {
             **FIG_BASE,
             "type": "SECTION",
+            "resizeToFit": False,
             "fillPaints": [
                 {
                     "type": "SOLID",

--- a/tests/converter/test_group.py
+++ b/tests/converter/test_group.py
@@ -20,7 +20,7 @@ class TestFrameStyles:
         assert len(g.layers) == 1
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
     def test_clip_mask(self):
         g = tree.convert_node(FIG_GROUP, "")
@@ -28,10 +28,10 @@ class TestFrameStyles:
         assert len(g.layers) == 2
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         clip = g.layers[0]
-        assert clip.hasClippingMask == True
+        assert clip.hasClippingMask
         assert clip.clippingMaskMode == ClippingMaskMode.OUTLINE
 
     def test_background(self):
@@ -53,10 +53,10 @@ class TestFrameStyles:
         assert len(g.layers) == 3
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         clip = g.layers[0]
-        assert clip.hasClippingMask == True
+        assert clip.hasClippingMask
         assert clip.clippingMaskMode == ClippingMaskMode.OUTLINE
 
         bg = g.layers[1]
@@ -83,10 +83,10 @@ class TestFrameStyles:
         assert len(g.layers) == 3  # Clip mask, child, blur
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         blur = g.layers[2]
-        assert blur.style.blur.isEnabled == True
+        assert blur.style.blur.isEnabled
         assert blur.style.blur.type == BlurType.BACKGROUND
         assert blur.style.blur.radius == 2
 
@@ -107,10 +107,10 @@ class TestFrameStyles:
         assert len(g.layers) == 3  # bg_blur, clip mask, child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         blur = g.layers[1]
-        assert blur.style.blur.isEnabled == True
+        assert blur.style.blur.isEnabled
         assert blur.style.blur.type == BlurType.BACKGROUND
         assert blur.style.blur.radius == 2
 
@@ -134,7 +134,7 @@ class TestFrameStyles:
         assert len(g.layers) == 2  # clip mask, child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         assert g.style.shadows == [
             Shadow(blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1])
@@ -160,7 +160,7 @@ class TestFrameStyles:
         assert len(g.layers) == 2  # clip mask, child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         child = g.layers[1]
         assert child.style.innerShadows == [
@@ -195,7 +195,7 @@ class TestFrameStyles:
         assert len(g.layers) == 3  # clip mask, background, child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert g.style.blur.isEnabled == False
+        assert not g.style.blur.isEnabled
 
         bg = g.layers[1]
         assert len(bg.style.fills) == 1
@@ -205,6 +205,34 @@ class TestFrameStyles:
         assert bg.style.innerShadows == [
             InnerShadow(blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1])
         ]
+
+    def test_section_as_group(self):
+        fig_section = {
+            **FIG_BASE,
+            "type": "SECTION",
+            "fillPaints": [
+                {
+                    "type": "SOLID",
+                    "color": FIG_COLOR[0],
+                    "opacity": 0.9,
+                    "visible": True,
+                }
+            ],
+            "children": [{**FIG_BASE, "type": "ROUNDED_RECTANGLE"}],
+        }
+
+        group = tree.convert_node(fig_section, "")
+
+        assert group._class == "group"
+        assert group.style.fills == []
+        assert group.style.borders == []
+
+        clip = group.layers[0]
+        assert clip.hasClippingMask
+
+        bg = group.layers[1]
+        assert len(bg.style.fills) == 1
+        assert bg.style.fills[0].fillType == FillType.COLOR
 
 
 class TestResizingConstraints:


### PR DESCRIPTION
This PR adds basic support for sections which need to be handled the same way as frames in .fig files: if they hang directly under a canvas they're converted as artboards, and if they hang under another frame then they're converted as groups.

Fixes #60 