### PR TITLE
⎶ Avoid duplicated IDs when handling overrides

### DIFF
--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -54,7 +54,7 @@ def base_layer(fig_node: dict) -> _BaseLayer:
         fig_node["size"] = {"x": 1, "y": 1}
 
     return {
-        "do_objectID": utils.gen_object_id(fig_node.get("overrideKey", fig_node["guid"])),
+        "do_objectID": utils.gen_object_id(fig_node["guid"]),
         "name": fig_node["name"],
         "booleanOperation": -1,
         "exportOptions": export_options(fig_node.get("exportSettings", [])),

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -107,7 +107,7 @@ def get_all_overrides(fig_instance):
         existing = [i for i in unique_overrides if i["guidPath"]["guids"] == guid]
         if existing:
             # Add properties to the previous override. Priority goes to the first item
-            # because we want to priorize prop assignments which we always convert first
+            # because we want to prioritize prop assignments which we always convert first
             for k, v in ov.items():
                 if k == "guidPath":
                     continue
@@ -124,7 +124,10 @@ def convert_override(override: dict) -> Tuple[List[OverrideValue], List[str]]:
     unsupported_overrides = []
 
     # Convert uuids in the path from top symbol to child instance
-    sketch_path = [utils.gen_object_id(guid) for guid in override["guidPath"]["guids"]]
+    sketch_path = [
+        utils.gen_object_id(context.fig_node(guid)["guid"])
+        for guid in override["guidPath"]["guids"]
+    ]
     sketch_path_str = "/".join(sketch_path)
 
     for prop, value in override.items():

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -38,12 +38,12 @@ CONVERTERS: Dict[str, Callable[[dict], AbstractLayer]] = {
 }
 
 POST_PROCESSING: Dict[str, Callable[[dict, Any], AbstractLayer]] = {
+    "CANVAS": page.add_page_background,
+    "ARTBOARD": artboard.post_process_frame,
+    "GROUP": group.post_process_frame,
     "BOOLEAN_OPERATION": shape_group.post_process,
     "SYMBOL": symbol.move_to_symbols_page,
-    "GROUP": group.post_process_frame,
-    "ARTBOARD": artboard.post_process_frame,
     "INSTANCE": instance.post_process,
-    "CANVAS": page.add_page_background,
 }
 
 

--- a/src/figformat/fig2tree.py
+++ b/src/figformat/fig2tree.py
@@ -1,8 +1,7 @@
-import functools
 import io
 import logging
 import shutil
-from typing import Tuple, Sequence, Dict, IO
+from typing import Tuple, Sequence, Dict
 from converter import utils
 from zipfile import ZipFile
 from . import decodefig, vector_network

--- a/tests/converter/test_base.py
+++ b/tests/converter/test_base.py
@@ -1,7 +1,6 @@
 import pytest
 from .base import *
 from converter import prototype, tree, base
-from converter.positioning import Matrix
 from sketchformat.style import *
 from unittest.mock import ANY
 from converter.context import context
@@ -17,6 +16,14 @@ FIG_ARTBOARD = {
 @pytest.fixture
 def no_prototyping(monkeypatch):
     monkeypatch.setattr(prototype, "prototyping_information", lambda _: {})
+
+
+@pytest.mark.usefixtures("no_prototyping")
+class TestIDs:
+    def test_avoid_duplicated_ids(self):
+        ab = tree.convert_node({**FIG_ARTBOARD, "overrideKey": (789, 112)}, "CANVAS")
+
+        assert ab.do_objectID == utils.gen_object_id(FIG_ARTBOARD["guid"])
 
 
 @pytest.mark.usefixtures("no_prototyping")

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -1,10 +1,10 @@
 from .base import *
-import pytest
-from converter.context import context
-from converter.config import config
-from converter import tree
-from sketchformat.layer_group import Group, SymbolInstance, OverrideValue
 import copy
+import pytest
+from converter import tree
+from converter.config import config
+from converter.context import context
+from sketchformat.layer_group import Group, SymbolInstance, OverrideValue
 from unittest.mock import ANY
 
 FIG_TEXT = {
@@ -17,6 +17,7 @@ FIG_TEXT = {
     "fillPaints": [{"type": "SOLID", "color": FIG_COLOR[0], "opacity": 0.9, "visible": True}],
     "textData": {"characters": "original"},
     "guid": (0, 1),
+    "overrideKey": (1, 9),
     "componentPropRefs": [
         {
             "defID": (1, 0),
@@ -48,7 +49,7 @@ FIG_INSTANCE = {
 
 @pytest.fixture
 def symbol(monkeypatch):
-    context.init(None, {(0, 3): FIG_SYMBOL, (0, 1): FIG_TEXT, (0, 2): FIG_RECT})
+    context.init(None, {(0, 3): FIG_SYMBOL, (0, 1): FIG_TEXT, (0, 2): FIG_RECT, (1, 9): FIG_TEXT})
     context._component_symbols = {(0, 3): False}
 
 
@@ -76,7 +77,7 @@ class TestOverrides:
     def test_text_override(self):
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [
-            {"guidPath": {"guids": [(0, 1)]}, "textData": {"characters": "modified"}}
+            {"guidPath": {"guids": [(1, 9)]}, "textData": {"characters": "modified"}}
         ]
 
         i = tree.convert_node(fig, "")
@@ -111,7 +112,7 @@ class TestOverrides:
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [
             {
-                "guidPath": {"guids": [(0, 1)]},
+                "guidPath": {"guids": [(1, 9)]},
                 "fillPaints": [
                     {
                         "type": "SOLID",
@@ -165,7 +166,7 @@ class TestOverrides:
 
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [
-            {"guidPath": {"guids": [(0, 1)]}, "textData": {"characters": "override"}}
+            {"guidPath": {"guids": [(1, 9)]}, "textData": {"characters": "override"}}
         ]
         fig["componentPropAssignments"] = [
             {"defID": (1, 0), "value": {"textValue": {"characters": "property"}}}

--- a/tests/converter/test_prototype.py
+++ b/tests/converter/test_prototype.py
@@ -151,9 +151,7 @@ class TestConvertFlow:
             ]
         }
 
-        fig_artboard = {**FIG_BASE, **fig_flow}
-
-        flow = convert_flow(fig_artboard)
+        flow = convert_flow({**FIG_BASE, **fig_flow})
 
         warnings.assert_any_call("PRT001", ANY, props=["DRAG"])
         warnings.assert_any_call("PRT003", ANY, props=["BACK"])
@@ -204,9 +202,7 @@ class TestConvertFlow:
             ]
         }
 
-        fig_artboard = {**FIG_BASE, **overlay_flow}
-
-        flow = convert_flow(fig_artboard)
+        flow = convert_flow({**FIG_BASE, **overlay_flow})
 
         assert flow["flow"].destinationArtboardID == utils.gen_object_id((0, 5))
         assert flow["flow"].animationType == AnimationType.SLIDE_FROM_LEFT
@@ -235,9 +231,7 @@ class TestConvertFlow:
             ]
         }
 
-        fig_artboard = {**FIG_BASE, **overlay_flow}
-
-        flow = convert_flow(fig_artboard)
+        flow = convert_flow({**FIG_BASE, **overlay_flow})
 
         assert flow["flow"].destinationArtboardID == utils.gen_object_id((0, 6))
         assert flow["flow"].animationType == AnimationType.SLIDE_FROM_TOP

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -1,6 +1,5 @@
 from .base import *
 from converter import tree, prototype
-from sketchformat.layer_common import ClippingMaskMode
 from sketchformat.layer_shape import Rectangle
 import pytest
 from converter.context import context


### PR DESCRIPTION
From bug reported in [this thread](https://sketch.slack.com/archives/C042X7DDDTK/p1670840731366069?thread_ts=1670839802.162329&cid=C042X7DDDTK)

This PRs prevents duplicated IDs that were being introduced for overrides in symbol instances.