### PR TITLE
➿ Avoid infinite loop trying to apply innerShadow to a symbol master

### DIFF
--- a/src/converter/artboard.py
+++ b/src/converter/artboard.py
@@ -11,7 +11,7 @@ def convert(fig_frame: dict) -> Artboard:
     obj = Artboard(
         **base.base_styled(fig_frame),
         **prototype.prototyping_information(fig_frame),
-        grid=convert_grid(fig_frame)
+        grid=convert_grid(fig_frame),
     )
 
     obj.layout = convert_layout(fig_frame, obj.frame)

--- a/src/converter/group.py
+++ b/src/converter/group.py
@@ -134,10 +134,9 @@ def convert_frame_style(fig_group: dict, sketch_group: AbstractLayerGroup) -> Ab
     return sketch_group
 
 
-def apply_inner_shadow(layer: AbstractStyledLayer, shadow: InnerShadow) -> None:
-    if isinstance(layer, Group):
-        for child in layer.layers:
-            if isinstance(child, AbstractStyledLayer):
-                apply_inner_shadow(child, shadow)
-    else:
-        layer.style.innerShadows.append(shadow)
+def apply_inner_shadow(layer: AbstractLayerGroup, shadow: InnerShadow) -> None:
+    for child in layer.layers:
+        if isinstance(child, AbstractLayerGroup):
+            apply_inner_shadow(child, shadow)
+        elif isinstance(child, AbstractStyledLayer):
+            child.style.innerShadows.append(shadow)

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -197,7 +197,7 @@ def convert_properties_to_overrides(fig_master, properties, guid_path=[]):
     overrides = []
 
     for prop in properties:
-        for (ref_prop, ref_guid) in find_refs(fig_master, prop["defID"]):
+        for ref_prop, ref_guid in find_refs(fig_master, prop["defID"]):
             if ref_prop["componentPropNodeField"] == "OVERRIDDEN_SYMBOL_ID":
                 override = {"overriddenSymbolID": prop["value"]["guidValue"]}
             elif ref_prop["componentPropNodeField"] == "TEXT_DATA":

--- a/src/converter/shape.py
+++ b/src/converter/shape.py
@@ -14,5 +14,5 @@ def convert_star(fig_star):
     return Star(
         **base.base_shape(fig_star),
         numberOfPoints=fig_star["count"],
-        radius=fig_star["starInnerScale"]
+        radius=fig_star["starInnerScale"],
     )

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -23,7 +23,7 @@ def convert(fig_symbol):
     master = SymbolMaster(
         **base.base_styled(fig_symbol),
         **prototype.prototyping_information(fig_symbol),
-        symbolID=utils.gen_object_id(fig_symbol["guid"])
+        symbolID=utils.gen_object_id(fig_symbol["guid"]),
     )
 
     # Keep the base ID as the symbol reference, create a new one for the container

--- a/src/converter/text.py
+++ b/src/converter/text.py
@@ -185,7 +185,6 @@ def override_characters_style(fig_text):
     for pos, (style_id, character) in enumerate(
         zip(all_character_styles, fig_text["textData"]["characters"])
     ):
-
         # A glyph without a character is an added bullet point (for lists). Skip it
         while "firstCharacter" not in next_glyph:
             utils.log_conversion_warning("TXT005", fig_text)

--- a/tests/converter/base.py
+++ b/tests/converter/base.py
@@ -1,7 +1,7 @@
 from converter.positioning import Matrix
 from sketchformat.style import *
 import pytest
-from converter import utils
+from converter import utils, prototype
 from unittest.mock import create_autospec
 
 FIG_BASE = {
@@ -50,3 +50,8 @@ def warnings(monkeypatch):
     mock = create_autospec(utils.log_conversion_warning)
     monkeypatch.setattr(utils, "log_conversion_warning", mock)
     return mock
+
+
+@pytest.fixture
+def no_prototyping(monkeypatch):
+    monkeypatch.setattr(prototype, "prototyping_information", lambda _: {})


### PR DESCRIPTION
If a symbol master was passed into `apply_inner_shadow`, it didn't match the `isinstance` if, so it tried to apply the shadow to the master itself. This modified itself while looping, which ended up adding infinite shadows to itself until it ran out of memory :boom: 

Fixes https://github.com/sketch-hq/Sketch/issues/48819