### PR TITLE
🪹 Skip empty shape paths

### DIFF
--- a/src/converter/shape_path.py
+++ b/src/converter/shape_path.py
@@ -8,6 +8,7 @@ from sketchformat.layer_shape import ShapePath, CurvePoint, CurveMode
 from sketchformat.common import WindingRule, Point
 from sketchformat.style import MarkerType
 from typing import Union, List, TypedDict, Tuple, Dict
+from .errors import Fig2SketchWarning
 
 STROKE_CAP_TO_MARKER_TYPE = {
     "NONE": MarkerType.NONE,
@@ -34,6 +35,9 @@ class _Markers(TypedDict, total=False):
 
 
 def convert(fig_vector: dict) -> Union[Group, ShapeGroup, ShapePath]:
+    if len(fig_vector["vectorNetwork"]["vertices"]) == 0:
+        raise Fig2SketchWarning("SHP002")
+
     fig_regions = get_all_segments(fig_vector["vectorNetwork"])
     regions = [convert_region(fig_vector, region, i) for i, region in enumerate(fig_regions)]
 

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -62,7 +62,7 @@ def convert_node(fig_node: dict, parent_type: str) -> AbstractLayer:
         try:
             children.append(convert_node(child, fig_node["type"]))
         except Fig2SketchWarning as w:
-            utils.log_conversion_warning(w.code, fig_node)
+            utils.log_conversion_warning(w.code, child)
         except Exception as e:
             logging.error(
                 f'An unexpected error occurred when converting {child["type"]}: {child["name"]} ({child["guid"]}). It will be skipped\n'

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -62,6 +62,7 @@ WARNING_MESSAGES = {
     "TXT005": "contains a LIST style with list markers. This style will be ignored",
     "TXT006": "uses OpenType features not supported by Sketch: {features}. They will be ignored",
     "SHP001": "contains a line with at least one 'Reversed triangle' end. This type of marker does not exist in Sketch. It has been converted to a 'Line' type marker",
+    "SHP002": "does not have any points. It will be skipped",
     "STY001": "contains a layer blur and a background blur. Only one will be converted",
     "STY002": "contains a DIAMOND gradient, which is not supported. It is converted to a RADIAL gradient",
     "STY003": "contains a fill with a non-standard blend mode, which is not supported at the fill level (us the layer blend mode instead). It will be ignored",

--- a/tests/converter/test_shape_path.py
+++ b/tests/converter/test_shape_path.py
@@ -6,6 +6,8 @@ from sketchformat.layer_group import ShapeGroup
 from sketchformat.layer_common import BooleanOperation
 from sketchformat.style import FillType, MarkerType, WindingRule
 from .base import FIG_BASE
+from converter.errors import Fig2SketchWarning
+import pytest
 
 FIG_VECTOR = {
     **FIG_BASE,
@@ -160,3 +162,19 @@ def test_complex_vector():
     assert len(groups[0].style.fills) == 0
     for path in groups[0].layers:
         assert isinstance(sp, ShapePath) == True
+
+
+def test_empty_path():
+    fig = {
+        **FIG_VECTOR,
+        "vectorNetwork": {
+            "regions": [],
+            "segments": [],
+            "vertices": [],
+        },
+    }
+
+    with pytest.raises(Fig2SketchWarning) as e:
+        tree.convert_node(fig, "DOCUMENT")
+
+    assert e.value.code == "SHP002"


### PR DESCRIPTION
A shape path with no points used to produce an error. This converts it to a warning so it's less scary to the user.

https://github.com/sketch-hq/Sketch/issues/48908 Case 1