### PR TITLE
🔼 Ignore invalid override keys

### DIFF
--- a/src/figformat/fig2tree.py
+++ b/src/figformat/fig2tree.py
@@ -28,7 +28,10 @@ def convert_fig(path: str, output: ZipFile) -> Tuple[dict, Dict[Sequence[int], d
         id_map[node_id] = node
 
         if "overrideKey" in node:
-            override_map[node["overrideKey"]] = node
+            if node["overrideKey"][0] == utils.UINT_MAX:
+                del node["overrideKey"]
+            else:
+                override_map[node["overrideKey"]] = node
 
         if not root:
             root = node_id


### PR DESCRIPTION
When overrideKey is set to the invalid value, ignore it from the early stage. If not, the instance override code gets confused trying to apply the override for a key that cannot be found (UINT_MAX).