### PR TITLE
🎬 Convert detached symbol instances to group/artboard as needed

### DIFF
--- a/src/converter/errors.py
+++ b/src/converter/errors.py
@@ -1,3 +1,7 @@
 class Fig2SketchWarning(Exception):
     def __init__(self, code: str):
         self.code = code
+
+
+class Fig2SketchNodeChanged(Exception):
+    pass

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -6,6 +6,7 @@ from converter import utils
 from sketchformat.layer_group import SymbolInstance, OverrideValue
 from sketchformat.style import Style
 from typing import List, Tuple
+from .errors import Fig2SketchNodeChanged
 
 
 def convert(fig_instance):
@@ -22,7 +23,9 @@ def convert(fig_instance):
 
             # Modify input tree in place, with the detached symbol subtree
             detach_symbol(fig_instance, all_overrides)
-            return group.convert(fig_instance)
+
+            # Raise an exception to trigger conversion of the detached node
+            raise Fig2SketchNodeChanged()
         else:
             utils.log_conversion_warning("SYM002", fig_instance, props=unsupported)
 
@@ -236,6 +239,7 @@ def detach_symbol(fig_instance, all_overrides):
         apply_overrides(c, fig_instance["guid"], all_overrides, fig_instance["derivedSymbolData"])
 
     fig_instance["children"] = detached_children
+    fig_instance["type"] = "FRAME"
 
 
 def apply_overrides(fig_node, instance_id, overrides, derived_symbol_data):

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -4,7 +4,7 @@ import pytest
 from converter import tree
 from converter.config import config
 from converter.context import context
-from sketchformat.layer_group import Group, SymbolInstance, OverrideValue
+from sketchformat.layer_group import Group, SymbolInstance, OverrideValue, Artboard
 from unittest.mock import ANY
 
 FIG_TEXT = {
@@ -182,3 +182,32 @@ class TestOverrides:
         assert i.overrideValues == [
             OverrideValue(overrideName=f"{symbol_text_id}_stringValue", value="property")
         ]
+
+
+@pytest.mark.usefixtures("symbol", "no_prototyping")
+class TestDetach:
+    def test_convert_to_group(self):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 9)]},
+                "fillPaints": [],
+            }
+        ]
+        fig["resizeToFit"] = False
+
+        i = tree.convert_node(fig, "")
+        assert isinstance(i, Group)
+
+    def test_convert_to_artboard(self):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 9)]},
+                "fillPaints": [],
+            }
+        ]
+        fig["resizeToFit"] = False
+
+        i = tree.convert_node(fig, "CANVAS")
+        assert isinstance(i, Artboard)


### PR DESCRIPTION
Previous to this patch, when instances were detached they always converted to groups. It ignored the rule we have that converts some of them to artboards.

This was a problem in a document with a prototype where the screens were symbol instances. It converted all of them to groups so it broke all the transition information. By converting the detached instances to artboards when appropriate, the prototype works correctly.