### PR TITLE
🔢 More flexible support of fig versions

### DIFF
--- a/src/figformat/kiwi.py
+++ b/src/figformat/kiwi.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import zlib
 import struct
 import io
+import logging
 
 
 class KiwiReader:
@@ -142,13 +143,18 @@ class KiwiDecoder:
 
 
 def decode(reader, type_converters):
-    SUPPORTED_VERSIONS = [15, 20]
+    MIN_SUPPORTED_VERSIONS = 15
+    MAX_SUPPORTED_VERSION = 25
 
     header = reader.read(12)
     fig_version = struct.unpack("<I", header[8:12])[0]
-    if fig_version not in SUPPORTED_VERSIONS:
+    if fig_version < MIN_SUPPORTED_VERSIONS:
         raise Exception(
-            f"Unsupported .fig version. File = {fig_version} / Supported = {SUPPORTED_VERSIONS}"
+            f"[FIG002] The .fig file has version {fig_version} which is older than the minimum supported ({MIN_SUPPORTED_VERSIONS}). Cannot convert"
+        )
+    elif fig_version > MAX_SUPPORTED_VERSION:
+        logging.info(
+            f"[FIG001] The .fig file has version {fig_version} which is newer than the maximum supported ({MAX_SUPPORTED_VERSION}). Some new properties may not be correctly converted"
         )
 
     segment_header = reader.read(4)


### PR DESCRIPTION
Changes between version 20 and 25:

```
--- schema20.txt	2023-04-17 10:53:43.271121864 +0200
+++ schema25.txt	2023-04-17 10:53:47.327788541 +0200
@@ -339,6 +339,11 @@
   WRAP = 1;
 }
 
+enum StackCounterAlignContent {
+  AUTO = 0;
+  SPACE_BETWEEN = 1;
+}
+
 enum ConnectionType {
   NONE = 0;
   INTERNAL_NODE = 1;
@@ -1159,6 +1164,7 @@
   LEFT = 3;
   BOTTOM = 4;
   RIGHT = 5;
+  CENTER = 6;
 }
 
 message ConnectorEndpoint {
@@ -1203,6 +1209,8 @@
 
 message EditInfo {
   string timestampIso8601 = 1;
+  string userId = 2;
+  uint lastEditedAt = 3;
 }
 
 enum EditorType {
@@ -1322,10 +1330,12 @@
   string fontVersion = 202;
   LeadingTrim leadingTrim = 322;
   bool hangingQuote = 337;
+  bool hangingList = 339;
   uint textUserLayoutVersion = 203;
   OpenTypeFeature[] toggledOnOTFeatures = 205;
   OpenTypeFeature[] toggledOffOTFeatures = 206;
   Hyperlink hyperlink = 223;
+  Mention mention = 340;
   FontVariation[] fontVariations = 260;
   uint textBidiVersion = 279;
   TextTruncation textTruncation = 280;
@@ -1419,6 +1429,7 @@
   float stackCounterSpacing = 324;
   OptionalVector minSize = 325;
   OptionalVector maxSize = 326;
+  StackCounterAlignContent stackCounterAlignContent = 343;
   GUID transitionNodeID = 139;
   GUID prototypeStartNodeID = 140;
   Color prototypeBackgroundColor = 141;
@@ -1555,6 +1566,8 @@
   MigrationStatus migrationStatus = 329;
   bool isSoftDeleted = 330;
   EditInfo editInfo = 331;
+  ColorProfile colorProfile = 341;
+  SymbolId detachedSymbolId = 342;
 }
 
 message VideoPlayback {
@@ -1632,6 +1645,7 @@
   BORDER_LEFT_WEIGHT = 20;
   BORDER_RIGHT_WEIGHT = 21;
   VARIANT_PROPERTIES = 22;
+  STACK_COUNTER_SPACING = 23;
 }
 
 message VariableModeBySetMap {
@@ -1891,6 +1905,7 @@
   PrototypeEvent event = 2;
   PrototypeAction[] actions = 3;
   bool isDeleted = 4;
+  int stateManagementVersion = 5;
 }
 
 message PrototypeEvent {
@@ -1909,6 +1924,7 @@
 
 message ConditionalActions {
   PrototypeAction[] actions = 1;
+  VariableData condition = 2;
 }
 
 message PrototypeAction {
@@ -1964,6 +1980,12 @@
   GUID guid = 2;
 }
 
+message Mention {
+  GUID id = 1;
+  string mentionedUserId = 2;
+  string mentionedByUserId = 3;
+}
+
 message EmbedData {
   string url = 1;
   string srcUrl = 2;
@@ -2230,6 +2252,7 @@
   EditorType pasteEditorType = 27;
   string postSyncActions = 28;
   GUID[] publishedAssetGuids = 29;
+  bool dirtyFromInitialLoad = 31;
 }
 
 message DiffChunk {
@@ -2355,91 +2378,29 @@
   Vector value = 1;
 }
 
-enum HTMLTag {
-  AUTO = 0;
-  ARTICLE = 1;
-  SECTION = 2;
-  NAV = 3;
-  ASIDE = 4;
-  H1 = 5;
-  H2 = 6;
-  H3 = 7;
-  H4 = 8;
-  H5 = 9;
-  H6 = 10;
-  HGROUP = 11;
-  HEADER = 12;
-  FOOTER = 13;
-  ADDRESS = 14;
-  P = 15;
-  HR = 16;
-  PRE = 17;
-  BLOCKQUOTE = 18;
-  OL = 19;
-  UL = 20;
-  MENU = 21;
-  LI = 22;
-  DL = 23;
-  DT = 24;
-  DD = 25;
-  FIGURE = 26;
-  FIGCAPTION = 27;
-  MAIN = 28;
-  DIV = 29;
-  A = 30;
-  EM = 31;
-  STRONG = 32;
-  SMALL = 33;
-  S = 34;
-  CITE = 35;
-  Q = 36;
-  DFN = 37;
-  ABBR = 38;
-  RUBY = 39;
-  RT = 40;
-  RP = 41;
-  DATA = 42;
-  TIME = 43;
-  CODE = 44;
-  VAR = 45;
-  SAMP = 46;
-  KBD = 47;
-  SUB = 48;
-  SUP = 49;
-  I = 50;
-  B = 51;
-  U = 52;
-  MARK = 53;
-  BDI = 54;
-  BDO = 55;
-  SPAN = 56;
-  BR = 57;
-  WBR = 58;
-  PICTURE = 59;
-  SOURCE = 60;
-  IMG = 61;
-  FORM = 62;
-  LABEL = 63;
-  INPUT = 64;
-  BUTTON = 65;
-  SELECT = 66;
-  DATALIST = 67;
-  OPTGROUP = 68;
-  OPTION = 69;
-  TEXTAREA = 70;
-  OUTPUT = 71;
-  PROGRESS = 72;
-  METER = 73;
-  FIELDSET = 74;
-  LEGEND = 75;
-}
-
 enum ARIARole {
   AUTO = 0;
   BUTTON = 1;
+  LINK = 4;
+  ARTICLE = 31;
+  PARAGRAPH = 54;
+  TABLE = 62;
+  NAVIGATION = 72;
+  IMAGE = 82;
+  HEADING_1 = 83;
+  HEADING_2 = 84;
+  HEADING_3 = 85;
+  HEADING_4 = 86;
+  HEADING_5 = 87;
+  HEADING_6 = 88;
+  HEADER = 89;
+  FOOTER = 90;
+  SIDEBAR = 91;
+  SECTION = 92;
+  MAINCONTENT = 93;
+  TABLE_CELL = 94;
   CHECKBOX = 2;
   GRIDCELL = 3;
-  LINK = 4;
   MENUITEM = 5;
   MENUITEMCHECKBOX = 6;
   MENUITEMRADIO = 7;
@@ -2466,7 +2427,6 @@
   TREE = 28;
   TREEGRID = 29;
   APPLICATION = 30;
-  ARTICLE = 31;
   BLOCKQUOTE = 32;
   CAPTION = 33;
   CELL = 34;
@@ -2489,7 +2449,6 @@
   METER = 51;
   NONE = 52;
   NOTE = 53;
-  PARAGRAPH = 54;
   PRESENTATION = 55;
   ROW = 56;
   ROWGROUP = 57;
@@ -2497,7 +2456,6 @@
   STRONG = 59;
   SUBSCRIPT = 60;
   SUPERSCRIPT = 61;
-  TABLE = 62;
   TERM = 63;
   TIME = 64;
   TOOLBAR = 65;
@@ -2507,7 +2465,6 @@
   CONTENTINFO = 69;
   FORM = 70;
   MAIN = 71;
-  NAVIGATION = 72;
   REGION = 73;
   SEARCH = 74;
   ALERT = 75;
@@ -2532,3 +2489,87 @@
   uint field = 2;
   uint lastModifiedSequenceNumber = 3;
 }
+
+enum ColorProfile {
+  SRGB = 0;
+  DISPLAY_P3 = 1;
+}
+
+enum HTMLTag {
+  AUTO = 0;
+  ARTICLE = 1;
+  SECTION = 2;
+  NAV = 3;
+  ASIDE = 4;
+  H1 = 5;
+  H2 = 6;
+  H3 = 7;
+  H4 = 8;
+  H5 = 9;
+  H6 = 10;
+  HGROUP = 11;
+  HEADER = 12;
+  FOOTER = 13;
+  ADDRESS = 14;
+  P = 15;
+  HR = 16;
+  PRE = 17;
+  BLOCKQUOTE = 18;
+  OL = 19;
+  UL = 20;
+  MENU = 21;
+  LI = 22;
+  DL = 23;
+  DT = 24;
+  DD = 25;
+  FIGURE = 26;
+  FIGCAPTION = 27;
+  MAIN = 28;
+  DIV = 29;
+  A = 30;
+  EM = 31;
+  STRONG = 32;
+  SMALL = 33;
+  S = 34;
+  CITE = 35;
+  Q = 36;
+  DFN = 37;
+  ABBR = 38;
+  RUBY = 39;
+  RT = 40;
+  RP = 41;
+  DATA = 42;
+  TIME = 43;
+  CODE = 44;
+  VAR = 45;
+  SAMP = 46;
+  KBD = 47;
+  SUB = 48;
+  SUP = 49;
+  I = 50;
+  B = 51;
+  U = 52;
+  MARK = 53;
+  BDI = 54;
+  BDO = 55;
+  SPAN = 56;
+  BR = 57;
+  WBR = 58;
+  PICTURE = 59;
+  SOURCE = 60;
+  IMG = 61;
+  FORM = 62;
+  LABEL = 63;
+  INPUT = 64;
+  BUTTON = 65;
+  SELECT = 66;
+  DATALIST = 67;
+  OPTGROUP = 68;
+  OPTION = 69;
+  TEXTAREA = 70;
+  OUTPUT = 71;
+  PROGRESS = 72;
+  METER = 73;
+  FIELDSET = 74;
+  LEGEND = 75;
+}
```