### PR TITLE
Fix tests by updating the expected SHA1 of Inter-Regular.ttf

### DIFF
--- a/tests/integration/test_structure.py
+++ b/tests/integration/test_structure.py
@@ -91,11 +91,11 @@ def test_document(sketch_doc):
         assert doc["fontReferences"] == [
             {
                 "_class": "fontReference",
-                "do_objectID": "45406576-C7A2-4277-9C6E-B60F3D54ECC3",
+                "do_objectID": "46BF164E-CB00-4E1A-A5DE-9E6EB74A4F1F",
                 "fontData": {
                     "_class": "MSJSONFileReference",
                     "_ref_class": "MSFontData",
-                    "_ref": "fonts/07f64e2c2cfb24e6899ca67886d4ca9ed1c089c1",
+                    "_ref": "fonts/be10cc8996f037af7331dc965bae42ef33478700",
                 },
                 "fontFamilyName": "Inter",
                 "fontFileName": "Inter-Regular.ttf",
@@ -116,7 +116,7 @@ def test_document(sketch_doc):
     [
         "images/616d10a80971e08c6b43a164746afac1972c7ccc.png",
         "images/92e4d5e0c24ffd632c3db3264e62cc907c2f5e29",
-        "fonts/07f64e2c2cfb24e6899ca67886d4ca9ed1c089c1",
+        "fonts/be10cc8996f037af7331dc965bae42ef33478700",
     ],
 )
 def test_file_hashes(sketch_doc, img):
@@ -223,7 +223,7 @@ def test_files(sketch_doc):
         "images/92e4d5e0c24ffd632c3db3264e62cc907c2f5e29",
         "pages/8F292FCA-49C0-4E31-957E-93FB2D1A7231.json",
         "pages/A4E5259A-9CE6-49D9-B4A1-A8062C205347.json",
-        "fonts/07f64e2c2cfb24e6899ca67886d4ca9ed1c089c1",
+        "fonts/be10cc8996f037af7331dc965bae42ef33478700",
         "document.json",
         "user.json",
         "meta.json",


### PR DESCRIPTION
The hardcoded font file hash corresponds to a previous version of the font and Google Fonts has been serving a new version ([v4](https://github.com/rsms/inter/releases)) for a while now, thus the change.

P.S. I've intentionally avoided updating any `.fig` test documents in this PR as doing so would reveal other issues that should be addressed separately.