### PR TITLE
ci: use github hosted arm runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
             ext: '.exe'
           - os: macos
             arch: x86_64
-            runs: macos-latest
+            runs: macos-12
             ext: ''
           - os: macos
             arch: arm64
-            runs: self-hosted
+            runs: macos-14
             ext: ''
 
     runs-on: ${{ matrix.runs }}


### PR DESCRIPTION
GitHub Actions supports M1 runners now. To avoid unexpected changes, x86_64 now uses macos-12 explicitly, arm64 uses macos-14 explicitly, following what the current default is for macos-latest.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories