### PR TITLE
🎨 Add support for P3 color space

### DIFF
--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -16,7 +16,10 @@ def find_symbols(node: dict) -> List[Sequence[int]]:
 
 
 class Context:
-    def init(self, components_page: Optional[dict], id_map: Dict[Sequence[int], dict]) -> None:
+    def init(
+        self, components_page: Optional[dict], id_map: Dict[Sequence[int], dict], color_space: str
+    ) -> None:
+        self._color_space = color_space
         self._sketch_components: Dict[Sequence[int], Swatch] = {}
         self.symbols_page = None
         self._node_by_id = id_map
@@ -28,6 +31,9 @@ class Context:
         # Where to position symbols of the specified width
         # width -> (x, y)
         self._symbol_position = {0: [0, 0]}
+
+    def color_space(self) -> int:
+        return 2 if self._color_space == "DISPLAY_P3" else 1
 
     def component(self, cid: Sequence[int]) -> Tuple[dict, Optional[Swatch]]:
         fig_component = self.fig_node(cid)

--- a/src/converter/convert.py
+++ b/src/converter/convert.py
@@ -14,7 +14,12 @@ def convert_fig_tree_to_sketch(
     # We should either bring the fonts to the same indexed_components to pass
     # them as parameter or move the indexed components to the component file
     # and store there the components, for consistency purposes
-    context.init(components_page, id_map)
+    if "documentColorProfile" in fig["document"]:
+        color_space = fig["document"]["documentColorProfile"]
+    else:
+        color_space = "sRGB"
+
+    context.init(components_page, id_map, color_space)
 
     # Convert all normal pages
     sketch_pages: List[Page] = convert_pages(fig_pages, output)

--- a/src/converter/document.py
+++ b/src/converter/document.py
@@ -23,7 +23,7 @@ def convert(pages: List[Page], output_zip: zipfile.ZipFile) -> dict:
             "gradients": [],
             "exportPresets": [],
         },
-        "colorSpace": 1,
+        "colorSpace": context.color_space(),
         "currentPageIndex": 0,
         "foreignLayerStyles": [],
         "foreignSymbols": [],

--- a/tests/converter/test_base.py
+++ b/tests/converter/test_base.py
@@ -113,7 +113,7 @@ FIG_TEXT_STYLE = {
 
 @pytest.fixture
 def style_overrides(monkeypatch):
-    context.init(None, {(0, 1): FIG_TEXT_STYLE, (0, 2): FIG_COLOR_STYLE})
+    context.init(None, {(0, 1): FIG_TEXT_STYLE, (0, 2): FIG_COLOR_STYLE}, "DISPLAY_P3")
 
 
 @pytest.mark.usefixtures("style_overrides")

--- a/tests/converter/test_image.py
+++ b/tests/converter/test_image.py
@@ -10,7 +10,7 @@ from .base import FIG_BASE, warnings
 
 def test_corrupted_images(warnings):
     figtree, id_map = fig2tree.convert_fig("tests/data/broken_images.fig", None)
-    context.init(None, id_map)
+    context.init(None, id_map, "DISPLAY_P3")
     figpage = figtree["document"]["children"][0]
     page = tree.convert_node(figpage, "DOCUMENT")
 

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -49,7 +49,11 @@ FIG_INSTANCE = {
 
 @pytest.fixture
 def symbol(monkeypatch):
-    context.init(None, {(0, 3): FIG_SYMBOL, (0, 1): FIG_TEXT, (0, 2): FIG_RECT, (1, 9): FIG_TEXT})
+    context.init(
+        None,
+        {(0, 3): FIG_SYMBOL, (0, 1): FIG_TEXT, (0, 2): FIG_RECT, (1, 9): FIG_TEXT},
+        "DISPLAY_P3",
+    )
     context._component_symbols = {(0, 3): False}
 
 

--- a/tests/converter/test_prototype.py
+++ b/tests/converter/test_prototype.py
@@ -74,17 +74,18 @@ def canvas(monkeypatch):
             (0, 4): FIG_ARTBOARD,
             (0, 5): FIG_OVERLAY,
         },
+        "DISPLAY_P3",
     )
 
 
 @pytest.fixture
 def overlay(monkeypatch):
-    context.init(None, {(0, 5): FIG_OVERLAY})
+    context.init(None, {(0, 5): FIG_OVERLAY}, "DISPLAY_P3")
 
 
 @pytest.fixture
 def manual_overlay(monkeypatch):
-    context.init(None, {(0, 6): FIG_MANUAL_OVERLAY})
+    context.init(None, {(0, 6): FIG_MANUAL_OVERLAY}, "DISPLAY_P3")
 
 
 @pytest.mark.usefixtures("canvas")

--- a/tests/converter/test_shape_path.py
+++ b/tests/converter/test_shape_path.py
@@ -139,7 +139,7 @@ class TestArrows:
 
 def test_complex_vector():
     figtree, id_map = fig2tree.convert_fig("tests/data/vector.fig", None)
-    context.init(None, id_map)
+    context.init(None, id_map, "DISPLAY_P3")
     figpage = figtree["document"]["children"][0]
     page = tree.convert_node(figpage, "DOCUMENT")
     vector = page.layers[0].layers[0]

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -13,7 +13,7 @@ FIG_SYMBOL = {
 
 @pytest.fixture
 def empty_context(monkeypatch):
-    context.init(None, {})
+    context.init(None, {}, "DISPLAY_P3")
 
 
 def test_rounded_corners(no_prototyping, empty_context):


### PR DESCRIPTION
Adds support for setting the output Sketch document's colour space to either sRGB or P3 based on the fig input
