### PR TITLE
🔨 Improve the reliability of web font matching

### DIFF
--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -71,7 +71,7 @@ class Context:
             font_file, font_name = font.get_webfont(*font_descriptor)
         except Exception as e:
             if isinstance(e, font.FontNotFoundError) or (
-                isinstance(e, HTTPError) and e.code == 404
+                isinstance(e, HTTPError) and (e.code == 404 or e.code == 400)
             ):
                 logging.warning(f"Could not find font {font_descriptor} via Google Fonts")
             else:


### PR DESCRIPTION
With https://github.com/sketch-hq/fig2sketch/pull/118 we patched google web font downloading to fix a breaking change on Google's end.

However, the font matching wasn't the most reliable, as we attempted to match against file names rather than the family and style names from the font file itself. I've refactored this to use the more reliable latter. However, the downside is downloading each font file for the family. The previous implementation did this but as a single ZIP file. Given fonts are typically very small, and ZIPing them appears to make a negligible difference, I've gone for a slight bandwidth increase for better reliability/conversion results.

Note: We will still see some errors downloading fonts regarding text styles with additional variant info in subfamily strings (such as "Italic"). But I'm keen to avoid trimming/fiddling with the subfamily string too much.