### PR TITLE
👀 Fallback to sensible defaults when reading some fig node properties

### DIFF
--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -60,8 +60,8 @@ def base_layer(fig_node: dict) -> _BaseLayer:
         "exportOptions": export_options(fig_node.get("exportSettings", [])),
         **positioning.convert(fig_node),  # type: ignore
         "isFixedToViewport": False,
-        "isLocked": fig_node["locked"],
-        "isVisible": fig_node["visible"],
+        "isLocked": fig_node.get("locked", False),
+        "isVisible": fig_node.get("visible", True),
         "layerListExpandedType": LayerListStatus.COLLAPSED,
         "nameIsFixed": False,
         "resizingConstraint": resizing_constraint(fig_node),
@@ -224,8 +224,8 @@ VERTICAL_CONSTRAINT = {k: v << 3 for k, v in HORIZONTAL_CONSTRAINT.items()}
 
 
 def resizing_constraint(fig_node: dict) -> int:
-    h = HORIZONTAL_CONSTRAINT[fig_node["horizontalConstraint"]]
-    v = VERTICAL_CONSTRAINT[fig_node["verticalConstraint"]]
+    h = HORIZONTAL_CONSTRAINT[fig_node.get("horizontalConstraint", "MIN")]
+    v = VERTICAL_CONSTRAINT[fig_node.get("verticalConstraint", "MIN")]
     return h + v
 
 

--- a/src/converter/group.py
+++ b/src/converter/group.py
@@ -18,7 +18,7 @@ def convert(fig_group):
 def post_process_frame(fig_group: dict, sketch_group: Group) -> Group:
     convert_frame_style(fig_group, sketch_group)
 
-    if fig_group["resizeToFit"]:
+    if fig_group.get("resizeToFit", False):
         adjust_group_resizing_constraint(fig_group, sketch_group)
     else:
         # For frames converted to groups, add clipmask, resize children, etc

--- a/src/converter/shape_path.py
+++ b/src/converter/shape_path.py
@@ -350,14 +350,16 @@ def get_or_create_point(
 
 
 def points_marker_types(fig_vector: dict, start_point: dict, end_point: dict) -> _Markers:
-    start_marker_type = STROKE_CAP_TO_MARKER_TYPE[fig_vector["strokeCap"]]
-    end_marker_type = STROKE_CAP_TO_MARKER_TYPE[fig_vector["strokeCap"]]
+    start_marker_type = STROKE_CAP_TO_MARKER_TYPE[fig_vector.get("strokeCap", "NONE")]
+    end_marker_type = STROKE_CAP_TO_MARKER_TYPE[fig_vector.get("strokeCap", "NONE")]
 
     if ("style" in start_point) and ("strokeCap" in start_point["style"]):
-        start_marker_type = STROKE_CAP_TO_MARKER_TYPE[start_point["style"]["strokeCap"]]
+        start_marker_type = STROKE_CAP_TO_MARKER_TYPE[
+            start_point["style"].get("strokeCap", "NONE")
+        ]
 
     if ("style" in end_point) and ("strokeCap" in end_point["style"]):
-        end_marker_type = STROKE_CAP_TO_MARKER_TYPE[end_point["style"]["strokeCap"]]
+        end_marker_type = STROKE_CAP_TO_MARKER_TYPE[end_point["style"].get("strokeCap", "NONE")]
 
     if STROKE_CAP_TO_MARKER_TYPE["TRIANGLE_FILLED"] in [
         start_marker_type,

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -186,7 +186,7 @@ def cropped_image_layer(fig_node: dict, fill: dict) -> dict:
 
     iw = fill["originalImageWidth"]
     ih = fill["originalImageHeight"]
-    image_scale = Matrix.scale(1.0 / iw, 1.0 / ih)
+    image_scale = Matrix.scale(1.0 / iw if iw else 1, 1.0 / ih if ih else 1)
     layer_scale = Matrix.scale(fig_node["size"]["x"], fig_node["size"]["y"])
 
     transform = layer_scale * invmat * image_scale
@@ -194,7 +194,7 @@ def cropped_image_layer(fig_node: dict, fill: dict) -> dict:
     height = transform.dot2([0, ih]).length()
     width = transform.dot2([iw, 0]).length()
 
-    normalize_scale = Matrix.scale(iw / width, ih / height)
+    normalize_scale = Matrix.scale(iw / width if iw else 1, ih / height if ih else 1)
 
     image_layer = {
         "type": "RECTANGLE",

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -64,7 +64,7 @@ def convert(fig_node: dict) -> Style:
         do_objectID=utils.gen_object_id(fig_node["guid"], b"style"),
         borderOptions=BorderOptions(
             lineCapStyle=(
-                LINE_CAP_STYLE[fig_node["strokeCap"]]
+                LINE_CAP_STYLE[fig_node.get("strokeCap", "NONE")]
                 if "strokeCap" in fig_node
                 else BorderOptions.__dict__["lineCapStyle"]
             ),
@@ -160,10 +160,10 @@ def convert_crop_image_to_mask(fig_node: dict) -> None:
             "guid": old["guid"] + (0, 0),
             "size": old["size"],
             "transform": old["transform"],
-            "locked": old["locked"],
-            "visible": old["visible"],
-            "horizontalConstraint": old["horizontalConstraint"],
-            "verticalConstraint": old["verticalConstraint"],
+            "locked": old.get("locked", False),
+            "visible": old.get("visible", True),
+            "horizontalConstraint": old.get("horizontalConstraint", "MIN"),
+            "verticalConstraint": old.get("verticalConstraint", "MIN"),
             "blendMode": old["blendMode"],
             "opacity": old["opacity"],
             "resizeToFit": True,
@@ -201,10 +201,10 @@ def cropped_image_layer(fig_node: dict, fill: dict) -> dict:
         "name": f'{fig_node["name"]} (cropped image)',
         "size": {"x": width, "y": height},
         "transform": transform * normalize_scale,
-        "locked": fig_node["locked"],
-        "visible": fig_node["visible"],
-        "horizontalConstraint": fig_node["horizontalConstraint"],
-        "verticalConstraint": fig_node["verticalConstraint"],
+        "locked": fig_node.get("locked", False),
+        "visible": fig_node.get("visible", True),
+        "horizontalConstraint": fig_node.get("horizontalConstraint", "MIN"),
+        "verticalConstraint": fig_node.get("verticalConstraint", "MIN"),
         "blendMode": fig_node["blendMode"],
         "opacity": fig_node["opacity"],
         "fillPaints": [fill],

--- a/src/converter/text.py
+++ b/src/converter/text.py
@@ -131,15 +131,15 @@ def text_style(fig_text):
                 name=font_name, size=fig_text["fontSize"], featureSettings=font_features(fig_text)
             ),
             MSAttributedStringColorAttribute=color,
-            textStyleVerticalAlignmentKey=AlignVertical[fig_text["textAlignVertical"]],
+            textStyleVerticalAlignmentKey=AlignVertical[fig_text.get("textAlignVertical", "TOP")],
             **text_decoration(fig_text),
             kerning=kerning(fig_text),
             paragraphStyle=ParagraphStyle(
-                alignment=AlignHorizontal[fig_text["textAlignHorizontal"]],
+                alignment=AlignHorizontal[fig_text.get("textAlignHorizontal", "LEFT")],
                 **line_height(fig_text),
             ),
         ),
-        verticalAlignment=AlignVertical[fig_text["textAlignVertical"]],
+        verticalAlignment=AlignVertical[fig_text.get("textAlignVertical", "TOP")],
     )
 
     if fig_text.get("paragraphSpacing", 0) != 0:

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -95,7 +95,7 @@ def get_node_type(fig_node: dict, parent_type: str) -> str:
     # If a Frame is detected inside another Frame, the internal one
     # is considered a group
     if fig_node["type"] in ["FRAME", "SECTION"]:
-        if parent_type == "CANVAS" and not fig_node["resizeToFit"]:
+        if parent_type == "CANVAS" and not fig_node.get("resizeToFit", False):
             return "ARTBOARD"
         else:
             return "GROUP"


### PR DESCRIPTION
We've recently had instances of some frame and text layer properties not being written to the `.fig` model data. In these cases, we will fall back on the default values.

I have tackled the most common/those we've encountered but haven't provided defaults for everything at this time.