### PR TITLE
🗜️ Support `zstd` compression algorithm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ build-backend = "setuptools.build_meta"
 enabled = true
 
 [project.optional-dependencies]
-fast = ["fig-kiwi==0.1.0"]
-dev = ["black==24.2.0", "mypy==0.991", "pytest==8.2.0", "fig-kiwi==0.1.0"]
+fast = ["fig-kiwi==0.1.1"]
+dev = ["black==24.2.0", "mypy==0.991", "pytest==8.2.0", "fig-kiwi==0.1.1"]
 
 [tool.black]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,12 @@ name = "fig2sketch"
 readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["version"]
-dependencies = ["Pillow==10.3.0", "fonttools==4.43.0", "appdirs==1.4.4"]
+dependencies = [
+  "Pillow==10.3.0",
+  "fonttools==4.43.0",
+  "appdirs==1.4.4",
+  "zstd==1.5.5.1",
+]
 
 [project.scripts]
 fig2sketch = "fig2sketch:main"

--- a/src/figformat/decodefig.py
+++ b/src/figformat/decodefig.py
@@ -21,14 +21,14 @@ def decode(path):
     if header == b"PK":
         fig_zip = zipfile.ZipFile(reader)
 
-    # try:
-    #     import fig_kiwi
+    try:
+        import fig_kiwi
 
-    #     logging.debug("Using fast (rust) kiwi reader")
-    #     return fig_kiwi.decode(path, type_converters), fig_zip
+        logging.debug("Using fast (rust) kiwi reader")
+        return fig_kiwi.decode(path, type_converters), fig_zip
 
-    # except ImportError:
-    #     logging.debug("Falling back to slow (python) kiwi reader")
+    except ImportError:
+        logging.debug("Falling back to slow (python) kiwi reader")
 
     if fig_zip:
         reader = fig_zip.open("canvas.fig")

--- a/src/figformat/decodefig.py
+++ b/src/figformat/decodefig.py
@@ -21,14 +21,14 @@ def decode(path):
     if header == b"PK":
         fig_zip = zipfile.ZipFile(reader)
 
-    try:
-        import fig_kiwi
+    # try:
+    #     import fig_kiwi
 
-        logging.debug("Using fast (rust) kiwi reader")
-        return fig_kiwi.decode(path, type_converters), fig_zip
+    #     logging.debug("Using fast (rust) kiwi reader")
+    #     return fig_kiwi.decode(path, type_converters), fig_zip
 
-    except ImportError:
-        logging.debug("Falling back to slow (python) kiwi reader")
+    # except ImportError:
+    #     logging.debug("Falling back to slow (python) kiwi reader")
 
     if fig_zip:
         reader = fig_zip.open("canvas.fig")

--- a/src/figformat/kiwi.py
+++ b/src/figformat/kiwi.py
@@ -145,7 +145,7 @@ class KiwiDecoder:
 
 def decode(reader, type_converters):
     MIN_SUPPORTED_VERSIONS = 15
-    MAX_SUPPORTED_VERSION = 25
+    MAX_SUPPORTED_VERSION = 70
 
     # `zstd` data will start with a magic number frame
     # the value of which is `0xfd2fb528`


### PR DESCRIPTION
We have noticed that some parts of the `fig` file are now compressed using `zstd`. This leads to a crash when importing newly exported figma documents.

This change checks the first four bytes of the compressed range to look for the `zstd` "magic number" and switches decompression libraries based on the result.
