### PR TITLE
Better handling of missing nodes and division by zero

### DIFF
--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -2,6 +2,7 @@ import logging
 from sketchformat.layer_common import *
 from sketchformat.layer_shape import *
 from sketchformat.style import *
+from .errors import *
 from typing import TypedDict
 
 from . import positioning, style, prototype, utils

--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -1,6 +1,7 @@
 import logging
 from urllib.error import HTTPError
 from . import component, page, font
+from .errors import Fig2SketchWarning
 from sketchformat.document import Swatch
 from typing import Sequence, Tuple, Optional, Dict, IO, List
 
@@ -59,7 +60,10 @@ class Context:
         self._position_symbol(sketch_symbol)
 
     def fig_node(self, fid: Sequence[int]) -> dict:
-        return self._node_by_id[fid]
+        if fid in self._node_by_id:
+            return self._node_by_id[fid]
+        else:
+            raise Fig2SketchWarning("NOD001")
 
     def record_font(self, fig_font_name):
         font_descriptor = (fig_font_name["family"], fig_font_name["style"])

--- a/src/converter/positioning.py
+++ b/src/converter/positioning.py
@@ -45,12 +45,18 @@ class Matrix(list):
                 [
                     safe_div(self[1][1], (self[0][0] * self[1][1] - self[0][1] * self[1][0])),
                     safe_div(self[0][1], (self[0][1] * self[1][0] - self[0][0] * self[1][1])),
-                    safe_div((self[0][2] * self[1][1] - self[0][1] * self[1][2]), (self[0][1] * self[1][0] - self[0][0] * self[1][1])),
+                    safe_div(
+                        (self[0][2] * self[1][1] - self[0][1] * self[1][2]),
+                        (self[0][1] * self[1][0] - self[0][0] * self[1][1]),
+                    ),
                 ],
                 [
                     safe_div(self[1][0], (self[0][1] * self[1][0] - self[0][0] * self[1][1])),
                     safe_div(self[0][0], (self[0][0] * self[1][1] - self[0][1] * self[1][0])),
-                    safe_div((self[0][2] * self[1][0] - self[0][0] * self[1][2]), (self[0][0] * self[1][1] - self[0][1] * self[1][0])),
+                    safe_div(
+                        (self[0][2] * self[1][0] - self[0][0] * self[1][2]),
+                        (self[0][0] * self[1][1] - self[0][1] * self[1][0]),
+                    ),
                 ],
                 [0, 0, 1],
             ]

--- a/src/converter/positioning.py
+++ b/src/converter/positioning.py
@@ -1,4 +1,5 @@
 import math
+from .utils import safe_div
 from .errors import Fig2SketchWarning
 from sketchformat.layer_common import Rect, AbstractLayer
 from typing import TypedDict, Tuple, List, Sequence
@@ -42,16 +43,14 @@ class Matrix(list):
         return Matrix(
             [
                 [
-                    self[1][1] / (self[0][0] * self[1][1] - self[0][1] * self[1][0]),
-                    self[0][1] / (self[0][1] * self[1][0] - self[0][0] * self[1][1]),
-                    (self[0][2] * self[1][1] - self[0][1] * self[1][2])
-                    / (self[0][1] * self[1][0] - self[0][0] * self[1][1]),
+                    safe_div(self[1][1], (self[0][0] * self[1][1] - self[0][1] * self[1][0])),
+                    safe_div(self[0][1], (self[0][1] * self[1][0] - self[0][0] * self[1][1])),
+                    safe_div((self[0][2] * self[1][1] - self[0][1] * self[1][2]), (self[0][1] * self[1][0] - self[0][0] * self[1][1])),
                 ],
                 [
-                    self[1][0] / (self[0][1] * self[1][0] - self[0][0] * self[1][1]),
-                    self[0][0] / (self[0][0] * self[1][1] - self[0][1] * self[1][0]),
-                    (self[0][2] * self[1][0] - self[0][0] * self[1][2])
-                    / (self[0][0] * self[1][1] - self[0][1] * self[1][0]),
+                    safe_div(self[1][0], (self[0][1] * self[1][0] - self[0][0] * self[1][1])),
+                    safe_div(self[0][0], (self[0][0] * self[1][1] - self[0][1] * self[1][0])),
+                    safe_div((self[0][2] * self[1][0] - self[0][0] * self[1][2]), (self[0][0] * self[1][1] - self[0][1] * self[1][0])),
                 ],
                 [0, 0, 1],
             ]

--- a/src/converter/prototype.py
+++ b/src/converter/prototype.py
@@ -1,5 +1,5 @@
 from .context import context
-from .errors import Fig2SketchWarning
+from .errors import *
 from converter import utils
 from sketchformat.prototype import *
 from typing import TypedDict, Tuple, Optional

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -187,7 +187,7 @@ def cropped_image_layer(fig_node: dict, fill: dict) -> dict:
 
     iw = fill.get("originalImageWidth", fig_node["size"]["x"])
     ih = fill.get("originalImageHeight", fig_node["size"]["y"])
-    image_scale = Matrix.scale(1.0 / iw if iw else 1, 1.0 / ih if ih else 1)
+    image_scale = Matrix.scale(safe_div(1.0, iw), safe_div(1.0, ih))
     layer_scale = Matrix.scale(fig_node["size"]["x"], fig_node["size"]["y"])
 
     transform = layer_scale * invmat * image_scale
@@ -195,7 +195,7 @@ def cropped_image_layer(fig_node: dict, fill: dict) -> dict:
     height = transform.dot2([0, ih]).length()
     width = transform.dot2([iw, 0]).length()
 
-    normalize_scale = Matrix.scale(iw / width if iw else 1, ih / height if ih else 1)
+    normalize_scale = Matrix.scale(safe_div(iw, width), safe_div(ih, height))
 
     image_layer = {
         "type": "RECTANGLE",

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -258,8 +258,9 @@ def convert_gradient(fig_node: dict, fig_fill: dict) -> Gradient:
         except:
             x_scale = 1
 
-        ellipse_ratio = safe_div(scaled_distance(point_from, point_ellipse, x_scale), scaled_distance(
-            point_from, point_to, x_scale)
+        ellipse_ratio = safe_div(
+            scaled_distance(point_from, point_ellipse, x_scale),
+            scaled_distance(point_from, point_to, x_scale),
         )
 
         return Gradient.Radial(

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -4,6 +4,7 @@ import math
 from .positioning import Vector, Matrix
 from converter import utils
 from sketchformat.style import *
+from .utils import safe_div
 from typing import List, TypedDict
 from .errors import Fig2SketchNodeChanged
 
@@ -257,8 +258,8 @@ def convert_gradient(fig_node: dict, fig_fill: dict) -> Gradient:
         except:
             x_scale = 1
 
-        ellipse_ratio = scaled_distance(point_from, point_ellipse, x_scale) / scaled_distance(
-            point_from, point_to, x_scale
+        ellipse_ratio = safe_div(scaled_distance(point_from, point_ellipse, x_scale), scaled_distance(
+            point_from, point_to, x_scale)
         )
 
         return Gradient.Radial(

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -7,10 +7,12 @@ from typing import Sequence, Dict, Optional
 
 issued_warnings: Dict[tuple[int, int], list[str]] = {}
 
-def safe_div(x,y):
+
+def safe_div(x: float, y: float) -> float:
     if y == 0:
         return 0
     return x / y
+
 
 def gen_object_id(fig_id: Sequence[int], suffix: bytes = b"") -> str:
     # Generate UUIDs by hashing the fig GUID with a salt

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -7,6 +7,10 @@ from typing import Sequence, Dict, Optional
 
 issued_warnings: Dict[tuple[int, int], list[str]] = {}
 
+def safe_div(x,y):
+    if y == 0:
+        return 0
+    return x / y
 
 def gen_object_id(fig_id: Sequence[int], suffix: bytes = b"") -> str:
     # Generate UUIDs by hashing the fig GUID with a salt
@@ -98,6 +102,7 @@ WARNING_MESSAGES = {
     "IMG003": "is missing from the .fig file, it will not be converted",
     "IMG004": "appears to be corrupted in the .fig file ({error}), it will not be converted",
     "LAY001": "is an unsupported layer type, it will not be converted",
+    "NOD001": "node could not be found",
 }
 
 


### PR DESCRIPTION
We have some issues where converting files may fail due to:
1. Division by zero - I've made an effort to cover most of these with a safe division function
2. Missing node - We now throw a specific fig2sketch warning so that its clearer/can be better handled in the future.