### PR TITLE
Update x86 runner to macOS13

### DIFF
--- a/.github/workflows/adhoc_build.yml
+++ b/.github/workflows/adhoc_build.yml
@@ -21,7 +21,7 @@ jobs:
             ext: ".exe"
           - os: macos
             arch: x86_64
-            runs: macos-12
+            runs: macos-13
             ext: ""
           - os: macos
             arch: arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             ext: ".exe"
           - os: macos
             arch: x86_64
-            runs: macos-12
+            runs: macos-13
             ext: ""
           - os: macos
             arch: arm64


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024.

This PR will update the existing runner to macOS13.