### PR TITLE
🥞  Implement stacks

### DIFF
--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -67,6 +67,17 @@ def base_layer(fig_node: dict) -> _BaseLayer:
         "nameIsFixed": False,
         "resizingConstraint": resizing_constraint(fig_node),
         "resizingType": ResizeType.STRETCH,
+        # TODO: Improve how we convert sizing behaviour
+        "horizontalSizing": (
+            SizingBehaviour.FILL
+            if fig_node.get("stackChildPrimaryGrow") == 1
+            else SizingBehaviour.FIXED
+        ),
+        "verticalSizing": (
+            SizingBehaviour.FILL
+            if fig_node.get("stackChildAlignSelf") == "STRETCH"
+            else SizingBehaviour.FIXED
+        ),
         **prototype.convert_flow(fig_node),  # type: ignore
         "isTemplate": False,
     }

--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -70,6 +70,7 @@ def base_layer(fig_node: dict) -> _BaseLayer:
         "resizingType": ResizeType.STRETCH,
         "horizontalSizing": horizontal_sizing_behaviour(fig_node),
         "verticalSizing": vertical_sizing_behaviour(fig_node),
+        "flexItem": flex_item(fig_node),
         **prototype.convert_flow(fig_node),  # type: ignore
         "isTemplate": False,
     }
@@ -259,6 +260,13 @@ def parent_stack_mode(fig_node: dict) -> Optional[FlexDirection]:
             return FlexDirection.VERTICAL
         else:
             return FlexDirection.HORIZONTAL
+
+    return None
+
+
+def flex_item(fig_node: dict) -> Optional[FlexItem]:
+    if fig_node.get("stackPositioning") == "ABSOLUTE":
+        return FlexItem(ignoreLayout=True)
 
     return None
 

--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -23,7 +23,7 @@ SUPPORTED_INHERIT_STYLES = {
         "paragraphSpacing",
     ),
     "inheritExportStyleID": (),  # Unused?
-    "inheritEffectStyleID": ("blur", "shadows"),
+    "inheritEffectStyleID": ("blurs", "shadows"),
     "inheritGridStyleID": ("layoutGrids"),
     "inheritFillStyleIDForBackground": (),  # Unused?
 }

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -2,6 +2,7 @@ import math
 from . import base, group, prototype, rectangle
 from converter import utils
 from sketchformat.layer_group import (
+    ClippingBehavior,
     Frame,
     FlexGroupLayout,
     FlexDirection,
@@ -22,6 +23,7 @@ def convert(fig_frame: dict) -> Frame:
         **base.base_styled(fig_frame),
         **prototype.prototyping_information(fig_frame),
         grid=convert_grid(fig_frame),
+        clippingBehavior=ClippingBehavior.NONE if fig_frame.get("frameMaskDisabled") else ClippingBehavior.DEFAULT,
         groupBehavior=1,
     )
 

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -8,6 +8,7 @@ from sketchformat.layer_group import (
     FlexJustify,
     FlexAlign,
     SimpleGrid,
+    SizingBehaviour,
     LayoutGrid,
     Rect,
 )

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -7,8 +7,8 @@ from sketchformat.layer_group import (
     FlexDirection,
     FlexJustify,
     FlexAlign,
+    PaddingSelection,
     SimpleGrid,
-    SizingBehaviour,
     LayoutGrid,
     Rect,
 )
@@ -25,11 +25,7 @@ def convert(fig_frame: dict) -> Frame:
     )
 
     if fig_frame.get("stackMode"):
-        obj.groupLayout = convert_group_layout(fig_frame)
-        obj.topPadding = fig_frame.get("stackVerticalPadding", 0)
-        obj.rightPadding = fig_frame.get("stackPaddingRight", 0)
-        obj.bottomPadding = fig_frame.get("stackPaddingBottom", 0)
-        obj.leftPadding = fig_frame.get("stackHorizontalPadding", 0)
+        obj = convert_auto_layout(obj, fig_frame)
 
     obj.layout = convert_layout(fig_frame, obj.frame)
 
@@ -44,6 +40,23 @@ def post_process_frame(fig_frame: dict, sketch_frame: Frame) -> Frame:
     # Figma stores its stack children in bottom up order, but Sketch uses top down
     if fig_frame.get("stackMode"):
         sketch_frame.layers.reverse()
+
+    return sketch_frame
+
+
+def convert_auto_layout(sketch_frame: Frame, fig_frame: dict) -> Frame:
+    sketch_frame.groupLayout = convert_group_layout(fig_frame)
+    sketch_frame.topPadding = fig_frame.get("stackVerticalPadding", 0)
+    sketch_frame.rightPadding = fig_frame.get("stackPaddingRight", 0)
+    sketch_frame.bottomPadding = fig_frame.get("stackPaddingBottom", 0)
+    sketch_frame.leftPadding = fig_frame.get("stackHorizontalPadding", 0)
+
+    sketch_frame.paddingSelection = (
+        PaddingSelection.INDIVIDUAL
+        if sketch_frame.topPadding != sketch_frame.bottomPadding
+        or sketch_frame.leftPadding != sketch_frame.rightPadding
+        else PaddingSelection.PAIRED
+    )
 
     return sketch_frame
 

--- a/src/converter/group.py
+++ b/src/converter/group.py
@@ -34,8 +34,19 @@ def adjust_group_resizing_constraint(fig_group: dict, sketch_group: Group) -> No
     if not sketch_group.layers:
         return
 
-    constraint = [sketch_group.layers[0].horizontalPins, sketch_group.layers[0].verticalPins]
-    if any([[l.horizontalPins, l.verticalPins] != constraint for l in sketch_group.layers[1:]]):
+    first_layer_constraint = [
+        sketch_group.layers[0].horizontalPins,
+        sketch_group.layers[0].verticalPins,
+    ]
+
+    constraints_are_inconsistent = False
+    for layer in sketch_group.layers[1:]:
+        current_constraint = [layer.horizontalPins, layer.verticalPins]
+        if current_constraint != first_layer_constraint:
+            constraints_are_inconsistent = True
+            break
+
+    if constraints_are_inconsistent:
         utils.log_conversion_warning("GRP002", fig_group)
 
     sketch_group.horizontalPins = sketch_group.layers[0].horizontalPins

--- a/src/converter/group.py
+++ b/src/converter/group.py
@@ -22,13 +22,10 @@ def post_process_frame(fig_group: dict, sketch_group: Group) -> Group:
 
     return sketch_group
 
-
 def adjust_group_resizing_constraint(fig_group: dict, sketch_group: Group) -> None:
     """Adjust the resizing constraint of the group to better match the .fig doc.
-
     Groups in .fig don't really have a resizing constraint. Instead, the children of the group resize
     relative to the parent of the group.
-
     If all childs have the same constraint, we can have the same behaviour in Sketch, by setting the group
     constraints to be equal to the sublayers.
     However, if there is a mix, we cannot replicate the behaviour, so we just choose some constraint and throw
@@ -36,12 +33,12 @@ def adjust_group_resizing_constraint(fig_group: dict, sketch_group: Group) -> No
     if not sketch_group.layers:
         return
 
-    constraint = sketch_group.layers[0].resizingConstraint
-    if any([l.resizingConstraint != constraint for l in sketch_group.layers[1:]]):
+    constraint = [sketch_group.layers[0].horizontalPins, sketch_group.layers[0].verticalPins]
+    if any([[l.horizontalPins, l.verticalPins] != constraint for l in sketch_group.layers[1:]]):
         utils.log_conversion_warning("GRP002", fig_group)
 
-    sketch_group.resizingConstraint = constraint
-
+    sketch_group.horizontalPins = sketch_group.layers[0].horizontalPins
+    sketch_group.verticalPins = sketch_group.layers[0].verticalPins
 
 def create_clip_mask_if_needed(fig_group: dict, sketch_group: AbstractLayerGroup) -> bool:
     needs_clip_mask = not fig_group.get("frameMaskDisabled", False)

--- a/src/converter/group.py
+++ b/src/converter/group.py
@@ -22,6 +22,7 @@ def post_process_frame(fig_group: dict, sketch_group: Group) -> Group:
 
     return sketch_group
 
+
 def adjust_group_resizing_constraint(fig_group: dict, sketch_group: Group) -> None:
     """Adjust the resizing constraint of the group to better match the .fig doc.
     Groups in .fig don't really have a resizing constraint. Instead, the children of the group resize
@@ -39,6 +40,7 @@ def adjust_group_resizing_constraint(fig_group: dict, sketch_group: Group) -> No
 
     sketch_group.horizontalPins = sketch_group.layers[0].horizontalPins
     sketch_group.verticalPins = sketch_group.layers[0].verticalPins
+
 
 def create_clip_mask_if_needed(fig_group: dict, sketch_group: AbstractLayerGroup) -> bool:
     needs_clip_mask = not fig_group.get("frameMaskDisabled", False)

--- a/src/converter/layout.py
+++ b/src/converter/layout.py
@@ -2,7 +2,6 @@ from typing import TypedDict, Union
 from converter import utils
 from sketchformat.layer_common import PaddingSelection
 from sketchformat.layer_group import (
-    AbstractLayerGroup,
     ClippingBehavior,
     Frame,
     FlexGroupLayout,
@@ -11,7 +10,6 @@ from sketchformat.layer_group import (
     FlexDirection,
     FlexJustify,
     FlexAlign,
-    SymbolMaster,
 )
 
 

--- a/src/converter/layout.py
+++ b/src/converter/layout.py
@@ -82,6 +82,8 @@ def convert_flex_justify(justify: str) -> FlexJustify:
         "MIN": FlexJustify.START,
         "CENTER": FlexJustify.CENTER,
         "MAX": FlexJustify.END,
+        # We seem to have a different interpretation of "SPACE_EVENLY"
+        "SPACE_EVENLY": FlexJustify.SPACE_BETWEEN,
     }
 
     return justify_mapping.get(justify, FlexJustify.START)

--- a/src/converter/layout.py
+++ b/src/converter/layout.py
@@ -1,0 +1,122 @@
+from typing import TypedDict, Union
+from converter import utils
+from sketchformat.layer_common import PaddingSelection
+from sketchformat.layer_group import (
+    AbstractLayerGroup,
+    ClippingBehavior,
+    Frame,
+    FlexGroupLayout,
+    FreeFormGroupLayout,
+    InferredGroupLayout,
+    FlexDirection,
+    FlexJustify,
+    FlexAlign,
+    SymbolMaster,
+)
+
+
+class _LayoutInformation(TypedDict, total=False):
+    groupLayout: Union[FreeFormGroupLayout, InferredGroupLayout, FlexGroupLayout]
+    clippingBehavior: ClippingBehavior
+    leftPadding: float
+    topPadding: float
+    rightPadding: float
+    bottomPadding: float
+    paddingSelection: PaddingSelection
+
+
+def layout_information(fig_frame: dict) -> _LayoutInformation:
+    layout = _LayoutInformation()
+
+    layout["clippingBehavior"] = (
+        ClippingBehavior.NONE if fig_frame.get("frameMaskDisabled") else ClippingBehavior.DEFAULT
+    )
+
+    if not utils.has_auto_layout(fig_frame):
+        return layout
+
+    layout["groupLayout"] = convert_group_layout(fig_frame)
+
+    # Set padding values from Figma frame
+    layout["topPadding"] = fig_frame.get("stackVerticalPadding", 0)
+    layout["rightPadding"] = fig_frame.get("stackPaddingRight", 0)
+    layout["bottomPadding"] = fig_frame.get("stackPaddingBottom", 0)
+    layout["leftPadding"] = fig_frame.get("stackHorizontalPadding", 0)
+
+    # Determine padding selection type based on symmetry
+    has_asymmetric_padding = (
+        layout["topPadding"] != layout["bottomPadding"]
+        or layout["leftPadding"] != layout["rightPadding"]
+    )
+
+    layout["paddingSelection"] = (
+        PaddingSelection.INDIVIDUAL if has_asymmetric_padding else PaddingSelection.PAIRED
+    )
+
+    return layout
+
+
+def convert_group_layout(fig_frame: dict) -> FlexGroupLayout:
+    # Determine stack direction
+    is_vertical = fig_frame["stackMode"] == "VERTICAL"
+    flex_direction = FlexDirection.VERTICAL if is_vertical else FlexDirection.HORIZONTAL
+
+    # Get spacing between items
+    all_gutters_gap = fig_frame.get("stackSpacing", 0)
+
+    # Convert alignment properties
+    primary_align = fig_frame.get("stackPrimaryAlignItems", "MIN")
+    counter_align = fig_frame.get("stackCounterAlignItems", "MIN")
+
+    justify = convert_flex_justify(primary_align)
+    align = convert_flex_align(counter_align)
+
+    return FlexGroupLayout(
+        flexDirection=flex_direction,
+        justifyContent=justify,
+        alignItems=align,
+        allGuttersGap=all_gutters_gap,
+    )
+
+
+def convert_flex_justify(justify: str) -> FlexJustify:
+    justify_mapping = {
+        "MIN": FlexJustify.START,
+        "CENTER": FlexJustify.CENTER,
+        "MAX": FlexJustify.END,
+    }
+
+    return justify_mapping.get(justify, FlexJustify.START)
+
+
+def convert_flex_align(alignment: str) -> FlexAlign:
+    align_mapping = {
+        "MIN": FlexAlign.START,
+        "CENTER": FlexAlign.CENTER,
+        "MAX": FlexAlign.END,
+    }
+
+    return align_mapping.get(alignment, FlexAlign.NONE)
+
+
+def post_process_group_layout(fig_node: dict, layer_group: Frame) -> Frame:
+    # If the layout has a child which is ignoring the Stack layout, and the stack
+    # has a "Last on top" z-index order, we'll remove the stack layout.
+    has_child_ignoring_layout = False
+
+    for layer in layer_group.layers:
+        if (
+            hasattr(layer, "flexItem")
+            and layer.flexItem
+            and getattr(layer.flexItem, "ignoreLayout", False)
+        ):
+            has_child_ignoring_layout = True
+            break
+
+    if has_child_ignoring_layout and not fig_node.get("stackReverseZIndex"):
+        layer_group.groupLayout = FreeFormGroupLayout()
+        utils.log_conversion_warning("STK001", fig_node)
+    else:
+        layer_group.layers.reverse()
+
+    return layer_group

--- a/src/converter/page.py
+++ b/src/converter/page.py
@@ -21,7 +21,6 @@ def make_page(guid: Sequence[int], name: str, suffix: bytes = b"") -> Page:
         do_objectID=utils.gen_object_id(guid, suffix),
         frame=Rect(height=0, width=0, x=0, y=0),
         name=name,
-        resizingConstraint=63,
         rotation=0.0,
         style=Style(do_objectID=utils.gen_object_id(guid, suffix + b"style")),
         hasClickThrough=True,
@@ -48,7 +47,6 @@ def add_page_background(fig_canvas, sketch_page):
                     do_objectID=utils.gen_object_id(fig_canvas["guid"], b"background_style"),
                     fills=[Fill.Color(background_color)],
                 ),
-                resizingConstraint=0,
                 rotation=0,
                 frame=Rect(
                     x=page_bbox[0] - 1000,

--- a/src/converter/positioning.py
+++ b/src/converter/positioning.py
@@ -100,7 +100,7 @@ def convert(fig_item: dict) -> _Positioning:
 
     return {
         "frame": Rect(
-            constrainProportions=fig_item.get("proportionsConstrained", False),
+            constrainProportions=True if "targetAspectRatio" in fig_item else False,
             height=fig_item["size"]["y"] or 0.1,
             width=fig_item["size"]["x"] or 0.1,
             x=coordinates[0],

--- a/src/converter/rectangle.py
+++ b/src/converter/rectangle.py
@@ -40,8 +40,8 @@ def make_background_rect(fig: dict, frame: Rect, name: str) -> Rectangle:
         name=name,
         frame=Rect(height=frame.height, width=frame.width, x=0, y=0),
         style=Style(do_objectID=utils.gen_object_id(fig["guid"], f"{name}_style".encode())),
-        resizingConstraint=base.HORIZONTAL_CONSTRAINT["STRETCH"]
-        + base.VERTICAL_CONSTRAINT["STRETCH"],
+        horizontalPins=2,
+        verticalPins=2,
         rotation=0,
         fixedRadius=radius,
         corners=corners,

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -115,9 +115,6 @@ def convert_border(fig_node: dict, fig_border: dict) -> Border:
 
 
 def convert_fill(fig_node: dict, fig_fill: dict) -> Fill:
-    if fig_fill.get("blendMode", "NORMAL") != "NORMAL":
-        utils.log_conversion_warning("STY003", fig_node)
-
     match fig_fill:
         case {"type": "EMOJI"}:
             raise Exception("Unsupported fill: EMOJI")
@@ -127,6 +124,7 @@ def convert_fill(fig_node: dict, fig_fill: dict) -> Fill:
             return Fill.Color(
                 convert_color(fig_fill["color"], fig_fill["opacity"]),
                 isEnabled=fig_fill["visible"],
+                blendMode=BLEND_MODE[fig_fill.get("blendMode", "NORMAL")],
             )
         case {"type": "IMAGE"}:
             if is_cropped_image(fig_fill) and not fig_node.get("f2s_cropped_image"):
@@ -142,12 +140,14 @@ def convert_fill(fig_node: dict, fig_fill: dict) -> Fill:
                 patternTileScale=fig_fill.get("scale", 1),
                 isEnabled=fig_fill["visible"],
                 opacity=fig_fill.get("opacity", 1),
+                blendMode=BLEND_MODE[fig_fill.get("blendMode", "NORMAL")],
             )
         case _:
             return Fill.Gradient(
                 convert_gradient(fig_node, fig_fill),
                 isEnabled=fig_fill["visible"],
                 opacity=fig_fill.get("opacity", 1),
+                blendMode=BLEND_MODE[fig_fill.get("blendMode", "NORMAL")],
             )
 
 

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -341,12 +341,12 @@ def rotated_stop(position: float, offset: float) -> float:
 
 
 class _Effects(TypedDict):
-    blur: Blur
+    blurs: List[Blur]
     shadows: List[Shadow]
 
 
 def convert_effects(fig_node: dict) -> _Effects:
-    sketch: _Effects = {"blur": Blur.Disabled(), "shadows": []}
+    sketch: _Effects = {"blurs": [], "shadows": []}
 
     for e in fig_node.get("effects", []):
         if e["type"] == "INNER_SHADOW":
@@ -375,23 +375,35 @@ def convert_effects(fig_node: dict) -> _Effects:
             )
 
         elif e["type"] == "FOREGROUND_BLUR":
-            if sketch["blur"].isEnabled:
+            if (
+                len(sketch["blurs"])
+                and hasattr(sketch["blurs"][0], "isEnabled")
+                and sketch["blurs"][0].isEnabled
+            ):
                 utils.log_conversion_warning("STY001", fig_node)
                 continue
 
-            sketch["blur"] = Blur(
-                radius=e["radius"] / 2,  # Looks best dividing by 2, no idea why,
-                type=BlurType.GAUSSIAN,
+            sketch["blurs"].append(
+                Blur(
+                    radius=e["radius"] / 2,  # Looks best dividing by 2, no idea why,
+                    type=BlurType.GAUSSIAN,
+                )
             )
 
         elif e["type"] == "BACKGROUND_BLUR":
-            if sketch["blur"].isEnabled:
+            if (
+                len(sketch["blurs"])
+                and hasattr(sketch["blurs"][0], "isEnabled")
+                and sketch["blurs"][0].isEnabled
+            ):
                 utils.log_conversion_warning("STY001", fig_node)
                 continue
 
-            sketch["blur"] = Blur(
-                radius=e["radius"] / 2,  # Looks best dividing by 2, no idea why,
-                type=BlurType.BACKGROUND,
+            sketch["blurs"].append(
+                Blur(
+                    radius=e["radius"] / 2,  # Looks best dividing by 2, no idea why,
+                    type=BlurType.BACKGROUND,
+                )
             )
 
         else:

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -404,7 +404,10 @@ def context_settings(fig_node: dict) -> ContextSettings:
     blend_mode = BLEND_MODE[fig_node.get("blendMode", "NORMAL")]
     opacity = fig_node.get("opacity", 1)
 
-    if blend_mode == BlendMode.NORMAL and opacity == 1:
+    # Figma's default blend mode is pass-through, but its not expressed as a
+    # value in the fig model. When "NORMAL" is set explicity we need to tweak Sketch'
+    # opacity to avoid pass-through.
+    if fig_node.get("blendMode") == "NORMAL" and opacity == 1:
         # Sketch interprets normal at 100% opacity as pass-through
         opacity = 0.99
 

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -1,3 +1,4 @@
+from converter.frame import convert_auto_layout
 from . import instance, group, base, prototype
 from .context import context
 from converter import utils
@@ -26,18 +27,11 @@ def convert(fig_symbol):
         symbolID=utils.gen_object_id(fig_symbol["guid"]),
     )
 
+    if utils.has_auto_layout(fig_symbol):
+        master = convert_auto_layout(master, fig_symbol)
+
     # Keep the base ID as the symbol reference, create a new one for the container
     master.do_objectID = utils.gen_object_id(fig_symbol["guid"], b"symbol_master")
-
-    # Also add group layout if auto-layout is enabled
-    axis = LAYOUT_AXIS[fig_symbol.get("stackMode", "NONE")]
-    if axis is not None:
-        anchor = LAYOUT_ANCHOR[fig_symbol.get("stackPrimaryAlignItems", "MIN")]
-
-        master.groupLayout = InferredGroupLayout(
-            axis=axis,
-            layoutAnchor=anchor,
-        )
 
     # Use better names for variants if possible
     try:
@@ -55,11 +49,12 @@ def move_to_symbols_page(fig_symbol, sketch_symbol):
     if utils.has_rounded_corners(fig_symbol):
         group.create_clip_mask_if_needed(fig_symbol, sketch_symbol)
 
-    # Apply frame transforms
-    group.convert_frame_style(fig_symbol, sketch_symbol)
-
     # After the entire symbol is converted, move it to the Symbols page
     context.add_symbol(sketch_symbol)
+
+    # Figma stores its stack children in bottom up order, but Sketch uses top down
+    if utils.has_auto_layout(fig_symbol):
+        sketch_symbol.layers.reverse()
 
     # Since we put the Symbol in a different page in Sketch, leave an instance where the
     # master used to be

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -1,34 +1,31 @@
-from converter.frame import convert_auto_layout
-from . import instance, group, base, prototype
+from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
 
-LAYOUT_AXIS = {
-    "NONE": None,
-    "HORIZONTAL": LayoutAxis.HORIZONTAL,
-    "VERTICAL": LayoutAxis.VERTICAL,
-}
+# LAYOUT_AXIS = {
+#     "NONE": None,
+#     "HORIZONTAL": LayoutAxis.HORIZONTAL,
+#     "VERTICAL": LayoutAxis.VERTICAL,
+# }
 
-LAYOUT_ANCHOR = {
-    "MIN": LayoutAnchor.MIN,
-    "CENTER": LayoutAnchor.MIDDLE,
-    "MAX": LayoutAnchor.MAX,
-    "BASELINE": LayoutAnchor.MIDDLE,
-    "SPACE_EVENLY": LayoutAnchor.MIDDLE,
-}
+# LAYOUT_ANCHOR = {
+#     "MIN": LayoutAnchor.MIN,
+#     "CENTER": LayoutAnchor.MIDDLE,
+#     "MAX": LayoutAnchor.MAX,
+#     "BASELINE": LayoutAnchor.MIDDLE,
+#     "SPACE_EVENLY": LayoutAnchor.MIDDLE,
+# }
 
 
 def convert(fig_symbol):
     # A symbol is an artboard with a symbolID
     master = SymbolMaster(
         **base.base_styled(fig_symbol),
+        **layout.layout_information(fig_symbol),
         **prototype.prototyping_information(fig_symbol),
         symbolID=utils.gen_object_id(fig_symbol["guid"]),
     )
-
-    if utils.has_auto_layout(fig_symbol):
-        master = convert_auto_layout(master, fig_symbol)
 
     # Keep the base ID as the symbol reference, create a new one for the container
     master.do_objectID = utils.gen_object_id(fig_symbol["guid"], b"symbol_master")
@@ -54,7 +51,7 @@ def move_to_symbols_page(fig_symbol, sketch_symbol):
 
     # Figma stores its stack children in bottom up order, but Sketch uses top down
     if utils.has_auto_layout(fig_symbol):
-        sketch_symbol.layers.reverse()
+        sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)
 
     # Since we put the Symbol in a different page in Sketch, leave an instance where the
     # master used to be

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -92,7 +92,7 @@ def convert_node(fig_node: dict, parent_type: str) -> AbstractLayer:
 
 def get_node_type(fig_node: dict, parent_type: str) -> str:
     if fig_node["type"] in ["FRAME", "SECTION"]:
-        if not fig_node.get("resizeToFit", False):
+        if not fig_node.get("resizeToFit", False) or fig_node.get("stackMode"):
             return "FRAME"
         else:
             return "GROUP"

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -92,7 +92,7 @@ def convert_node(fig_node: dict, parent_type: str) -> AbstractLayer:
 
 def get_node_type(fig_node: dict, parent_type: str) -> str:
     if fig_node["type"] in ["FRAME", "SECTION"]:
-        if not fig_node.get("resizeToFit", False) or fig_node.get("stackMode"):
+        if not fig_node.get("resizeToFit", False) or utils.has_auto_layout(fig_node):
             return "FRAME"
         else:
             return "GROUP"

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -106,6 +106,7 @@ WARNING_MESSAGES = {
     "IMG004": "appears to be corrupted in the .fig file ({error}), it will not be converted",
     "LAY001": "is an unsupported layer type, it will not be converted",
     "NOD001": "node could not be found",
+    "STK001": "has a stack layout with last on top ordering and a child which ignores the layout. This layout will not be converted.",
 }
 
 

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -60,6 +60,10 @@ def has_rounded_corners(fig: dict) -> bool:
     )
 
 
+def has_auto_layout(fig: dict) -> bool:
+    return bool(fig.get("stackMode"))
+
+
 # Commented messages are no longer used, but we keep them for referencing past errors
 WARNING_MESSAGES = {
     "TXT001": "is missing the glyphs property. If the text has unicode characters, it may not convert the format properly",

--- a/src/sketchformat/layer_common.py
+++ b/src/sketchformat/layer_common.py
@@ -50,6 +50,13 @@ class ResizeType(IntEnum):
     FLOAT = 2
 
 
+class SizingBehaviour(IntEnum):
+    FIXED = 0
+    FIT = 1
+    FILL = 2
+    RELATIVE = 3
+
+
 @dataclass(kw_only=True)
 class ExportFormat:
     _class: str = field(default="exportFormat")
@@ -99,6 +106,8 @@ class AbstractLayer:
     layerListExpandedType: LayerListStatus = LayerListStatus.UNDECIDED
     nameIsFixed: bool = False
     resizingType: ResizeType = ResizeType.STRETCH
+    horizontalSizing: SizingBehaviour = SizingBehaviour.FIXED
+    verticalSizing: SizingBehaviour = SizingBehaviour.FIXED
     shouldBreakMaskChain: bool = False
 
 

--- a/src/sketchformat/layer_common.py
+++ b/src/sketchformat/layer_common.py
@@ -6,6 +6,33 @@ from .prototype import FlowConnection
 from .style import Style, Color
 
 
+class PaddingSelection(IntEnum):
+    UNIFORM = 0
+    PAIRED = 1
+    INDIVIDUAL = 2
+
+
+class FlexDirection(IntEnum):
+    HORIZONTAL = 0
+    VERTICAL = 1
+
+
+class FlexJustify(IntEnum):
+    START = 0
+    CENTER = 1
+    END = 2
+    SPACE_BETWEEN = 3
+    SPACE_AROUND = 4
+    SPACE_EVENLY = 5
+
+
+class FlexAlign(IntEnum):
+    START = 0
+    CENTER = 1
+    END = 2
+    NONE = 5
+
+
 class ExportLayerOptions(IntEnum):
     ALL = 0
     SELECTED = 1
@@ -88,6 +115,14 @@ class Rect:
 
 
 @dataclass(kw_only=True)
+class FlexItem:
+    _class: str = field(default="MSImmutableFlexItem")
+    alignSelf: FlexAlign = FlexAlign.NONE
+    ignoreLayout: bool = False
+    preserveSpaceWhenHidden: bool = False
+
+
+@dataclass(kw_only=True)
 class AbstractLayer:
     do_objectID: str
     frame: Rect
@@ -108,6 +143,7 @@ class AbstractLayer:
     resizingType: ResizeType = ResizeType.STRETCH
     horizontalSizing: SizingBehaviour = SizingBehaviour.FIXED
     verticalSizing: SizingBehaviour = SizingBehaviour.FIXED
+    flexItem: Optional[FlexItem] = None
     shouldBreakMaskChain: bool = False
 
 

--- a/src/sketchformat/layer_common.py
+++ b/src/sketchformat/layer_common.py
@@ -127,7 +127,6 @@ class AbstractLayer:
     do_objectID: str
     frame: Rect
     name: str
-    resizingConstraint: int
     rotation: float
     booleanOperation: BooleanOperation = BooleanOperation.NONE
     exportOptions: ExportOptions = field(default_factory=ExportOptions)
@@ -141,8 +140,11 @@ class AbstractLayer:
     layerListExpandedType: LayerListStatus = LayerListStatus.UNDECIDED
     nameIsFixed: bool = False
     resizingType: ResizeType = ResizeType.STRETCH
+    verticalPins: int = 0
+    horizontalPins: int = 0
     horizontalSizing: SizingBehaviour = SizingBehaviour.FIXED
     verticalSizing: SizingBehaviour = SizingBehaviour.FIXED
+    resizingConstraint: int = 0
     flexItem: Optional[FlexItem] = None
     shouldBreakMaskChain: bool = False
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -15,6 +15,10 @@ class LayoutAnchor(IntEnum):
     MIDDLE = 1
     MAX = 2
 
+class ClippingBehavior(IntEnum):
+    DEFAULT = 0
+    CLIP_TO_BOUNDS = 1
+    NONE = 2
 
 @dataclass(kw_only=True)
 class RulerData:
@@ -78,6 +82,7 @@ class AbstractLayerGroup(AbstractStyledLayer):
     groupLayout: Union[FreeFormGroupLayout, InferredGroupLayout, FlexGroupLayout] = field(
         default_factory=FreeFormGroupLayout
     )
+    clippingBehavior: ClippingBehavior = ClippingBehavior.DEFAULT
     leftPadding: float = 0
     topPadding: float = 0
     rightPadding: float = 0

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -48,33 +48,6 @@ class LayoutGrid:
     isEnabled: bool = True
 
 
-class PaddingSelection(IntEnum):
-    UNIFORM = 0
-    PAIRED = 1
-    INDIVIDUAL = 2
-
-
-class FlexDirection(IntEnum):
-    HORIZONTAL = 0
-    VERTICAL = 1
-
-
-class FlexJustify(IntEnum):
-    START = 0
-    CENTER = 1
-    END = 2
-    SPACE_BETWEEN = 3
-    SPACE_AROUND = 4
-    SPACE_EVENLY = 5
-
-
-class FlexAlign(IntEnum):
-    START = 0
-    CENTER = 1
-    END = 2
-    NONE = 5
-
-
 @dataclass(kw_only=True)
 class FlexGroupLayout:
     _class: str = field(default="MSImmutableFlexGroupLayout")

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -15,10 +15,12 @@ class LayoutAnchor(IntEnum):
     MIDDLE = 1
     MAX = 2
 
+
 class ClippingBehavior(IntEnum):
     DEFAULT = 0
     CLIP_TO_BOUNDS = 1
     NONE = 2
+
 
 @dataclass(kw_only=True)
 class RulerData:

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -143,9 +143,6 @@ class Frame(AbstractLayerGroup):
     overlaySettings: Optional[FlowOverlaySettings] = None
     prototypeViewport: Optional[PrototypeViewport] = None
 
-    horizontalSizing: int = 0
-    verticalSizing: int = 0
-
     shouldBreakMaskChain: bool = True
     layerListExpandedType: LayerListStatus = LayerListStatus.EXPANDED
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -48,6 +48,36 @@ class LayoutGrid:
     isEnabled: bool = True
 
 
+class FlexDirection(IntEnum):
+    HORIZONTAL = 0
+    VERTICAL = 1
+
+
+class FlexJustify(IntEnum):
+    START = 0
+    CENTER = 1
+    END = 2
+    SPACE_BETWEEN = 3
+    SPACE_AROUND = 4
+    SPACE_EVENLY = 5
+
+
+class FlexAlign(IntEnum):
+    START = 0
+    CENTER = 1
+    END = 2
+    NONE = 5
+
+
+@dataclass(kw_only=True)
+class FlexGroupLayout:
+    _class: str = field(default="MSImmutableFlexGroupLayout")
+    flexDirection: FlexDirection = FlexDirection.HORIZONTAL
+    justifyContent: FlexJustify = FlexJustify.START
+    alignItems: FlexAlign = FlexAlign.START
+    allGuttersGap: int = 0
+
+
 @dataclass(kw_only=True)
 class FreeFormGroupLayout:
     _class: str = field(default="MSImmutableFreeformGroupLayout")
@@ -66,9 +96,13 @@ class InferredGroupLayout:
 class AbstractLayerGroup(AbstractStyledLayer):
     hasClickThrough: bool = False
     groupBehavior: int = 0
-    groupLayout: Union[FreeFormGroupLayout, InferredGroupLayout] = field(
+    groupLayout: Union[FreeFormGroupLayout, InferredGroupLayout, FlexGroupLayout] = field(
         default_factory=FreeFormGroupLayout
     )
+    leftPadding: float = 0
+    topPadding: float = 0
+    rightPadding: float = 0
+    bottomPadding: float = 0
     layers: List[AbstractLayer] = field(default_factory=list)
 
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -165,8 +165,7 @@ class OverrideProperty:
 class SymbolMaster(Frame):
     _class: str = field(default="symbolMaster")
     allowsOverrides: bool = True
-    includeBackgroundColorInInstance: bool = False
-    includeBackgroundColorInExport: bool = True
+    includeBackgroundColorInInstance: bool = True
     symbolID: str
     overrideProperties: List[OverrideProperty] = field(default_factory=list)
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -48,6 +48,12 @@ class LayoutGrid:
     isEnabled: bool = True
 
 
+class PaddingSelection(IntEnum):
+    UNIFORM = 0
+    PAIRED = 1
+    INDIVIDUAL = 2
+
+
 class FlexDirection(IntEnum):
     HORIZONTAL = 0
     VERTICAL = 1
@@ -75,7 +81,7 @@ class FlexGroupLayout:
     flexDirection: FlexDirection = FlexDirection.HORIZONTAL
     justifyContent: FlexJustify = FlexJustify.START
     alignItems: FlexAlign = FlexAlign.START
-    allGuttersGap: int = 0
+    allGuttersGap: float = 0
 
 
 @dataclass(kw_only=True)
@@ -103,6 +109,7 @@ class AbstractLayerGroup(AbstractStyledLayer):
     topPadding: float = 0
     rightPadding: float = 0
     bottomPadding: float = 0
+    paddingSelection: PaddingSelection = PaddingSelection.UNIFORM
     layers: List[AbstractLayer] = field(default_factory=list)
 
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -142,7 +142,7 @@ class Frame(AbstractLayerGroup):
     layout: Optional[LayoutGrid] = None
     hasBackgroundColor: bool = False
     backgroundColor: Color = field(default_factory=Color.White)
-    includeBackgroundColorInExport: bool = False
+    includeBackgroundColorInExport: bool = True
     resizesContent: bool = True
     isFlowHome: bool = False
     overlayBackgroundInteraction: OverlayBackgroundInteraction = OverlayBackgroundInteraction.NONE
@@ -166,6 +166,7 @@ class SymbolMaster(Frame):
     _class: str = field(default="symbolMaster")
     allowsOverrides: bool = True
     includeBackgroundColorInInstance: bool = False
+    includeBackgroundColorInExport: bool = True
     symbolID: str
     overrideProperties: List[OverrideProperty] = field(default_factory=list)
 

--- a/src/sketchformat/style.py
+++ b/src/sketchformat/style.py
@@ -284,10 +284,6 @@ class Blur:
     saturation: float = 1
     type: BlurType = BlurType.GAUSSIAN
 
-    @staticmethod
-    def Disabled() -> "Blur":
-        return Blur(isEnabled=False)
-
 
 @dataclass(kw_only=True)
 class Shadow:
@@ -335,7 +331,7 @@ class Style:
     colorControls: ColorControls = field(default_factory=ColorControls)
     startMarkerType: MarkerType = MarkerType.NONE
     endMarkerType: MarkerType = MarkerType.NONE
-    blur: Blur = field(default_factory=Blur.Disabled)
+    blurs: List[Blur] = field(default_factory=list)
     textStyle: Optional[TextStyle] = None
     shadows: List[Shadow] = field(default_factory=list)
     startDecorationType: Optional[MarkerType] = None  # Legacy, should match startMarkerType

--- a/src/sketchformat/style.py
+++ b/src/sketchformat/style.py
@@ -188,16 +188,28 @@ class Fill:
     image: Optional[Image] = None
 
     @staticmethod
-    def Color(color: Color, isEnabled: bool = True) -> "Fill":
-        return Fill(color=color, fillType=FillType.COLOR, isEnabled=isEnabled)
+    def Color(
+        color: Color, isEnabled: bool = True, blendMode: BlendMode = BlendMode.NORMAL
+    ) -> "Fill":
+        return Fill(
+            color=color,
+            fillType=FillType.COLOR,
+            isEnabled=isEnabled,
+            contextSettings=ContextSettings(blendMode=blendMode),
+        )
 
     @staticmethod
-    def Gradient(gradient: Gradient, isEnabled: bool, opacity: float = 1) -> "Fill":
+    def Gradient(
+        gradient: Gradient,
+        isEnabled: bool,
+        opacity: float = 1,
+        blendMode: BlendMode = BlendMode.NORMAL,
+    ) -> "Fill":
         return Fill(
             gradient=gradient,
             fillType=FillType.GRADIENT,
             isEnabled=isEnabled,
-            contextSettings=ContextSettings(opacity=opacity),
+            contextSettings=ContextSettings(opacity=opacity, blendMode=blendMode),
         )
 
     @staticmethod
@@ -207,6 +219,7 @@ class Fill:
         patternTileScale: float,
         isEnabled: bool,
         opacity: float = 1,
+        blendMode: BlendMode = BlendMode.NORMAL,
     ) -> "Fill":
         return Fill(
             image=Image(_ref=path),
@@ -214,7 +227,7 @@ class Fill:
             patternFillType=patternFillType,
             patternTileScale=patternTileScale,
             isEnabled=isEnabled,
-            contextSettings=ContextSettings(opacity=opacity),
+            contextSettings=ContextSettings(opacity=opacity, blendMode=blendMode),
         )
 
 

--- a/tests/converter/test_group.py
+++ b/tests/converter/test_group.py
@@ -20,7 +20,7 @@ class TestFrameStyles:
         assert len(g.layers) == 1
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
     def test_background(self):
         g = tree.convert_node(
@@ -41,14 +41,14 @@ class TestFrameStyles:
         assert len(g.layers) == 2
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
         bg = g.layers[0]
         assert len(bg.style.fills) == 1
         assert bg.style.fills[0].fillType == FillType.COLOR
         assert bg.style.fills[0].color == SKETCH_COLOR[0]
 
-        assert not bg.style.blur.isEnabled
+        assert bg.style.blurs == []
 
     def test_fg_blur(self):
         g = tree.convert_node(
@@ -67,12 +67,12 @@ class TestFrameStyles:
         assert len(g.layers) == 2  # child, blur
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
         blur = g.layers[1]
-        assert blur.style.blur.isEnabled
-        assert blur.style.blur.type == BlurType.BACKGROUND
-        assert blur.style.blur.radius == 2
+        assert blur.style.blurs[0].isEnabled
+        assert blur.style.blurs[0].type == BlurType.BACKGROUND
+        assert blur.style.blurs[0].radius == 2
 
     def test_bg_blur(self):
         g = tree.convert_node(
@@ -91,12 +91,12 @@ class TestFrameStyles:
         assert len(g.layers) == 2  # bg_blur, child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
         blur = g.layers[0]
-        assert blur.style.blur.isEnabled
-        assert blur.style.blur.type == BlurType.BACKGROUND
-        assert blur.style.blur.radius == 2
+        assert blur.style.blurs[0].isEnabled
+        assert blur.style.blurs[0].type == BlurType.BACKGROUND
+        assert blur.style.blurs[0].radius == 2
 
     def test_shadows(self):
         g = tree.convert_node(
@@ -119,7 +119,7 @@ class TestFrameStyles:
         assert len(g.layers) == 1  # child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
         assert g.style.shadows == [
             Shadow(blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1])
@@ -146,7 +146,7 @@ class TestFrameStyles:
         assert len(g.layers) == 1  # child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
         child = g.layers[0]
         assert child.style.shadows == [
@@ -189,7 +189,7 @@ class TestFrameStyles:
         assert len(g.layers) == 2  # background, child
         assert g.style.fills == []
         assert g.style.borders == []
-        assert not g.style.blur.isEnabled
+        assert g.style.blurs == []
 
         bg = g.layers[0]
         assert len(bg.style.fills) == 1

--- a/tests/converter/test_group.py
+++ b/tests/converter/test_group.py
@@ -231,4 +231,4 @@ class TestResizingConstraints:
         assert g.resizingConstraint == g.layers[0].resizingConstraint
         assert g.horizontalSizing != g.layers[1].resizingConstraint
 
-        warnings.assert_not_called()
+        warnings.assert_any_call("GRP002", ANY)

--- a/tests/converter/test_group.py
+++ b/tests/converter/test_group.py
@@ -215,8 +215,14 @@ class TestResizingConstraints:
         fig["children"].append({**FIG_BASE, "type": "ROUNDED_RECTANGLE"})
         g = tree.convert_node(fig, "")
 
-        assert g.resizingConstraint == g.layers[0].resizingConstraint
-        assert g.resizingConstraint == g.layers[1].resizingConstraint
+        assert [g.horizontalSizing, g.verticalSizing] == [
+            g.layers[0].horizontalSizing,
+            g.layers[0].verticalSizing,
+        ]
+        assert [g.horizontalSizing, g.verticalSizing] == [
+            g.layers[1].horizontalSizing,
+            g.layers[1].verticalSizing,
+        ]
 
         warnings.assert_not_called()
 
@@ -228,7 +234,13 @@ class TestResizingConstraints:
         )
         g = tree.convert_node(fig, "")
 
-        assert g.resizingConstraint == g.layers[0].resizingConstraint
-        assert g.horizontalSizing != g.layers[1].resizingConstraint
+        assert [g.horizontalSizing, g.verticalSizing] == [
+            g.layers[0].horizontalSizing,
+            g.layers[0].verticalSizing,
+        ]
+        assert [g.horizontalSizing, g.verticalSizing] != [
+            g.layers[1].horizontalSizing,
+            g.layers[1].verticalSizing,
+        ]
 
         warnings.assert_any_call("GRP002", ANY)

--- a/tests/converter/test_group.py
+++ b/tests/converter/test_group.py
@@ -229,6 +229,6 @@ class TestResizingConstraints:
         g = tree.convert_node(fig, "")
 
         assert g.resizingConstraint == g.layers[0].resizingConstraint
-        assert g.resizingConstraint != g.layers[1].resizingConstraint
+        assert g.horizontalSizing != g.layers[1].resizingConstraint
 
-        warnings.assert_any_call("GRP002", ANY)
+        warnings.assert_not_called()

--- a/tests/converter/test_layout.py
+++ b/tests/converter/test_layout.py
@@ -119,6 +119,23 @@ class TestLayoutJustify:
             flexDirection=FlexDirection.VERTICAL, justifyContent=FlexJustify.END
         )
 
+    def test_layout_justify_space_evenly(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackPrimaryAlignItems": "SPACE_EVENLY",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, justifyContent=FlexJustify.SPACE_BETWEEN
+        )
+
 
 @pytest.mark.usefixtures("no_prototyping")
 class TestLayoutAlignment:

--- a/tests/converter/test_layout.py
+++ b/tests/converter/test_layout.py
@@ -1,0 +1,308 @@
+import pytest
+from sketchformat.layer_common import FlexAlign, FlexDirection, FlexJustify, PaddingSelection
+from sketchformat.layer_group import ClippingBehavior, FlexGroupLayout, FreeFormGroupLayout
+from .base import *
+from converter import tree, frame
+
+
+@pytest.fixture
+def no_prototyping(monkeypatch):
+    monkeypatch.setattr(prototype, "prototyping_information", lambda _: {})
+
+
+@pytest.mark.usefixtures("no_prototyping")
+class TestLayout:
+    def test_no_layout(self):
+        sketch_frame = tree.convert_node(
+            {**FIG_BASE, "type": "FRAME", "resizeToFit": False, "children": []},
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FreeFormGroupLayout()
+
+    def test_horizontal_layout(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "HORIZONTAL",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.HORIZONTAL)
+
+    def test_vertical_layout(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+
+    def test_layout_spacing(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackSpacing": 10,
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, allGuttersGap=10
+        )
+
+
+@pytest.mark.usefixtures("no_prototyping")
+class TestLayoutJustify:
+    def test_layout_justify_min(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackPrimaryAlignItems": "MIN",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, justifyContent=FlexJustify.START
+        )
+
+    def test_layout_justify_center(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackPrimaryAlignItems": "CENTER",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, justifyContent=FlexJustify.CENTER
+        )
+
+    def test_layout_justify_max(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackPrimaryAlignItems": "MAX",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, justifyContent=FlexJustify.END
+        )
+
+
+@pytest.mark.usefixtures("no_prototyping")
+class TestLayoutAlignment:
+    def test_layout_alignment_min(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackCounterAlignItems": "MIN",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, alignItems=FlexAlign.START
+        )
+
+    def test_layout_alignment_center(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackCounterAlignItems": "CENTER",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, alignItems=FlexAlign.CENTER
+        )
+
+    def test_layout_alignment_max(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "stackCounterAlignItems": "MAX",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, alignItems=FlexAlign.END
+        )
+
+    def test_layout_alignment_not_set(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "children": [],
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(
+            flexDirection=FlexDirection.VERTICAL, alignItems=FlexAlign.START
+        )
+
+
+@pytest.mark.usefixtures("no_prototyping")
+class TestClipping:
+    def test_behaviour_default_when_not_set_explicitly(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+        assert sketch_frame.clippingBehavior == ClippingBehavior.DEFAULT
+
+    def test_behaviour_none_when_mask_disabled(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "frameMaskDisabled": True,
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+        assert sketch_frame.clippingBehavior == ClippingBehavior.NONE
+
+    def test_behaviour_default_when_mask_enabled(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "frameMaskDisabled": False,
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+        assert sketch_frame.clippingBehavior == ClippingBehavior.DEFAULT
+
+
+@pytest.mark.usefixtures("no_prototyping")
+class TestPadding:
+    def test_padding(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "children": [],
+                "stackVerticalPadding": 5,
+                "stackPaddingRight": 10,
+                "stackPaddingBottom": 15,
+                "stackHorizontalPadding": 20,
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+        assert sketch_frame.topPadding == 5
+        assert sketch_frame.rightPadding == 10
+        assert sketch_frame.bottomPadding == 15
+        assert sketch_frame.leftPadding == 20
+
+    def test_asymetrical_padding(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "children": [],
+                "stackVerticalPadding": 5,
+                "stackPaddingRight": 10,
+                "stackPaddingBottom": 15,
+                "stackHorizontalPadding": 20,
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+        assert sketch_frame.topPadding == 5
+        assert sketch_frame.rightPadding == 10
+        assert sketch_frame.bottomPadding == 15
+        assert sketch_frame.leftPadding == 20
+        assert sketch_frame.paddingSelection == PaddingSelection.INDIVIDUAL
+
+    def test_symetrical_padding(self):
+        sketch_frame = tree.convert_node(
+            {
+                **FIG_BASE,
+                "type": "FRAME",
+                "resizeToFit": False,
+                "stackMode": "VERTICAL",
+                "children": [],
+                "stackVerticalPadding": 5,
+                "stackPaddingRight": 10,
+                "stackPaddingBottom": 5,
+                "stackHorizontalPadding": 10,
+            },
+            "CANVAS",
+        )
+
+        assert sketch_frame.groupLayout == FlexGroupLayout(flexDirection=FlexDirection.VERTICAL)
+        assert sketch_frame.topPadding == 5
+        assert sketch_frame.rightPadding == 10
+        assert sketch_frame.bottomPadding == 5
+        assert sketch_frame.leftPadding == 10
+        assert sketch_frame.paddingSelection == PaddingSelection.PAIRED

--- a/tests/converter/test_style.py
+++ b/tests/converter/test_style.py
@@ -349,7 +349,7 @@ class TestConvertEffects:
                 ]
             }
         )
-        blur = effects["blur"]
+        blur = effects["blurs"][0]
         assert blur.isEnabled
         assert blur.type == BlurType.GAUSSIAN
         assert blur.radius == 2.5
@@ -365,7 +365,7 @@ class TestConvertEffects:
                 ]
             }
         )
-        blur = effects["blur"]
+        blur = effects["blurs"][0]
         assert blur.isEnabled
         assert blur.type == BlurType.BACKGROUND
         assert blur.radius == 2.5

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -31,34 +31,31 @@ def test_rounded_corners(no_prototyping, empty_context):
     assert symbol.layers[0].points[0].cornerRadius == 5
 
 
-# def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
-#     g = tree.convert_node(
-#         {
-#             **FIG_SYMBOL,
-#             "effects": [
-#                 {
-#                     "type": "INNER_SHADOW",
-#                     "radius": 4,
-#                     "spread": 0,
-#                     "offset": {"x": 1, "y": 3},
-#                     "color": FIG_COLOR[1],
-#                     "visible": True,
-#                 }
-#             ],
-#             "children": [{**FIG_BASE, "type": "ROUNDED_RECTANGLE"}],
-#         },
-#         "",
-#     )
+def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
+    g = tree.convert_node(
+        {
+            **FIG_SYMBOL,
+            "effects": [
+                {
+                    "type": "INNER_SHADOW",
+                    "radius": 4,
+                    "spread": 0,
+                    "offset": {"x": 1, "y": 3},
+                    "color": FIG_COLOR[1],
+                    "visible": True,
+                }
+            ],
+            "children": [{**FIG_BASE, "type": "ROUNDED_RECTANGLE"}],
+        },
+        "",
+    )
 
-#     symbol = context.symbols_page.layers[0]
-#     assert symbol.style.shadows == []
-
-#     [child] = symbol.layers
-#     assert child.style.shadows == [
-#         Shadow(
-#             blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1], isInnerShadow=True
-#         )
-#     ]
+    symbol = context.symbols_page.layers[0]
+    assert symbol.style.shadows == [
+        Shadow(
+            blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1], isInnerShadow=True
+        )
+    ]
 
 
 def test_variant_name():

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -31,34 +31,34 @@ def test_rounded_corners(no_prototyping, empty_context):
     assert symbol.layers[0].points[0].cornerRadius == 5
 
 
-def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
-    g = tree.convert_node(
-        {
-            **FIG_SYMBOL,
-            "effects": [
-                {
-                    "type": "INNER_SHADOW",
-                    "radius": 4,
-                    "spread": 0,
-                    "offset": {"x": 1, "y": 3},
-                    "color": FIG_COLOR[1],
-                    "visible": True,
-                }
-            ],
-            "children": [{**FIG_BASE, "type": "ROUNDED_RECTANGLE"}],
-        },
-        "",
-    )
+# def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
+#     g = tree.convert_node(
+#         {
+#             **FIG_SYMBOL,
+#             "effects": [
+#                 {
+#                     "type": "INNER_SHADOW",
+#                     "radius": 4,
+#                     "spread": 0,
+#                     "offset": {"x": 1, "y": 3},
+#                     "color": FIG_COLOR[1],
+#                     "visible": True,
+#                 }
+#             ],
+#             "children": [{**FIG_BASE, "type": "ROUNDED_RECTANGLE"}],
+#         },
+#         "",
+#     )
 
-    symbol = context.symbols_page.layers[0]
-    assert symbol.style.shadows == []
+#     symbol = context.symbols_page.layers[0]
+#     assert symbol.style.shadows == []
 
-    [child] = symbol.layers
-    assert child.style.shadows == [
-        Shadow(
-            blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1], isInnerShadow=True
-        )
-    ]
+#     [child] = symbol.layers
+#     assert child.style.shadows == [
+#         Shadow(
+#             blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1], isInnerShadow=True
+#         )
+#     ]
 
 
 def test_variant_name():


### PR DESCRIPTION
Adds support for converting Figma auto layout to Sketch Stack Layouts (introduced in Sketch `2025.1`)

## Todo
- [x] Implement basic vertical and horizontal stacks (`fixed`, `fill`)
- [x] Implement padding (both paired and individual options)
- [x] Implement stacks for symbols and instances
- [x] Implement `fit`/`hug contents`
- [x] Implement Sketch's `relative`
- [x] Implement new pinning model (`BCPinSet`)
- [X] Implement new `blurs` style model property
- [x] Tests 🧪 