### PR TITLE
⚙️ Replace Rust toolchain setup Github action

### DIFF
--- a/.github/workflows/adhoc_build.yml
+++ b/.github/workflows/adhoc_build.yml
@@ -34,11 +34,13 @@ jobs:
         with:
           python-version: "3.11"
           architecture: x64 # Otherwise the runner will try to download Python arm64, which is not available. x64 has support for both archs (universal2).
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+      - name: Install latest stable Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           override: true
+          cache: false
+          rustflags: "-A warnings"
       - name: Build
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,11 +26,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+      - name: Install latest stable Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           override: true
+          cache: false
+          rustflags: "-A warnings"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,13 @@ jobs:
         with:
           python-version: "3.11"
           architecture: x64 # Otherwise the runner will try to download Python arm64, which is not available. x64 has support for both archs (universal2).
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+      - name: Install latest stable Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           override: true
+          cache: false
+          rustflags: "-A warnings"
       - name: Build
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The previous action's ([`actions-rs/toolchain@v1`](https://github.com/actions-rs/toolchain)) repo has now been archived and is no longer maintained, and it's using soon to be deprecated workflow features (`set-output`).

So I've migrated this project's workflows to [`actions-rust-lang/setup-rust-toolchain@v1`](https://github.com/actions-rust-lang/setup-rust-toolchain)