### PR TITLE
🐞 Remove clipping masks from symbols and skip vectors missing regions

### DIFF
--- a/src/converter/group.py
+++ b/src/converter/group.py
@@ -53,16 +53,6 @@ def adjust_group_resizing_constraint(fig_group: dict, sketch_group: Group) -> No
     sketch_group.verticalPins = sketch_group.layers[0].verticalPins
 
 
-def create_clip_mask_if_needed(fig_group: dict, sketch_group: AbstractLayerGroup) -> bool:
-    needs_clip_mask = not fig_group.get("frameMaskDisabled", False)
-    if needs_clip_mask:
-        # Add a clipping rectangle matching the frame size. No need to recalculate bounds
-        # since the clipmask defines Sketch bounds (which match visible children)
-        sketch_group.layers.insert(0, rectangle.make_clipping_rect(fig_group, sketch_group.frame))
-
-    return needs_clip_mask
-
-
 def convert_frame_style(fig_group: dict, sketch_group: AbstractLayerGroup) -> AbstractLayerGroup:
     # Convert frame styles
     # - Fill/stroke/bgblur -> Rectangle on bottom with that style

--- a/src/converter/shape_path.py
+++ b/src/converter/shape_path.py
@@ -35,11 +35,14 @@ class _Markers(TypedDict, total=False):
 
 
 def convert(fig_vector: dict) -> Union[Group, ShapeGroup, ShapePath]:
-    if len(fig_vector["vectorNetwork"]["vertices"]) == 0:
+    if len(fig_vector["vectorNetwork"].get("vertices", [])) == 0:
         raise Fig2SketchWarning("SHP002")
 
     fig_regions = get_all_segments(fig_vector["vectorNetwork"])
     regions = [convert_region(fig_vector, region, i) for i, region in enumerate(fig_regions)]
+
+    if len(regions) == 0:
+        raise Fig2SketchWarning("SHP003")
 
     if len(regions) > 1:
         # Ignore positioning for children. TODO: We should probably be building these shapePaths by

--- a/src/converter/style.py
+++ b/src/converter/style.py
@@ -87,7 +87,9 @@ def convert(fig_node: dict) -> Style:
 
 def convert_corners(fig_node: dict) -> Optional[StyleCorners]:
     # Return None if no corner radius is specified
-    if not fig_node.get("cornerRadius", False):
+    if not fig_node.get("cornerRadius", False) and not fig_node.get(
+        "rectangleTopLeftCornerRadius", False
+    ):
         return None
 
     base_radius = float(fig_node.get("cornerRadius", 0))

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -43,9 +43,6 @@ def convert(fig_symbol):
 
 
 def move_to_symbols_page(fig_symbol, sketch_symbol):
-    if utils.has_rounded_corners(fig_symbol):
-        group.create_clip_mask_if_needed(fig_symbol, sketch_symbol)
-
     # After the entire symbol is converted, move it to the Symbols page
     context.add_symbol(sketch_symbol)
 

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -74,6 +74,7 @@ WARNING_MESSAGES = {
     "TXT006": "uses OpenType features not supported by Sketch: {features}. They will be ignored",
     "SHP001": "contains a line with at least one 'Reversed triangle' end. This type of marker does not exist in Sketch. It has been converted to a 'Line' type marker",
     "SHP002": "does not have any points. It will be skipped",
+    "SHP003": "does not have any regions. It will be skipped",
     "STY001": "contains a layer blur and a background blur. Only one will be converted",
     "STY002": "contains a DIAMOND gradient, which is not supported. It is converted to a RADIAL gradient",
     "STY003": "contains a fill with a non-standard blend mode, which is not supported at the fill level (us the layer blend mode instead). It will be ignored",

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -25,10 +25,7 @@ def test_rounded_corners(no_prototyping, empty_context):
     symbol = context.symbols_page.layers[0]
 
     assert instance.symbolID == symbol.symbolID
-
-    assert isinstance(symbol.layers[0], Rectangle)
-    assert symbol.layers[0].hasClippingMask
-    assert symbol.layers[0].points[0].cornerRadius == 5
+    assert symbol.style.corners.radii[0] == 5
 
 
 def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):


### PR DESCRIPTION
- **Introduce new error to handle vectors with no regions**
- **No need to clip symbols now that frames support corner radius in Sketch**
