### PR TITLE
🏃 Skip decoding `vectorNetwork` when nodes are missing `vectorNetworkBlob`

### DIFF
--- a/src/figformat/fig2tree.py
+++ b/src/figformat/fig2tree.py
@@ -61,7 +61,7 @@ def transform_node(fig, node, fig_zip, output):
         parent = node.pop("parentIndex")
         node["parent"] = {"guid": parent["guid"], "position": parent["position"]}
 
-    if "vectorData" in node:
+    if "vectorData" in node and "vectorNetworkBlob" in node["vectorData"]:
         blob_id = node["vectorData"]["vectorNetworkBlob"]
         scale = node["vectorData"]["normalizedSize"]
         style_table_override = utils.get_style_table_override(node["vectorData"])


### PR DESCRIPTION
Simple polygons (squares and rectangles) may no longer come with an explicit vector network defined, as the path can be inferred from the node's frame. `fig2sketch` is crashing when it encounters a `vectorData` map without a `vectorNetworkBlob` field.

Sketch will still render these nodes correctly without providing a vector network, and so we'll skip decoding them if `vectorNetworkBlob` isn't set.