### PR TITLE
Change the default value when reading `maskType` for `clippingMaskMode`

### DIFF
--- a/src/converter/base.py
+++ b/src/converter/base.py
@@ -233,7 +233,7 @@ def masking(fig_node: dict) -> _Masking:
     return {
         "shouldBreakMaskChain": False,
         "hasClippingMask": bool(fig_node.get("mask")),
-        "clippingMaskMode": CLIPPING_MODE[fig_node.get("maskType", "OUTLINE")],
+        "clippingMaskMode": CLIPPING_MODE[fig_node.get("maskType", "ALPHA")],
     }
 
 


### PR DESCRIPTION
Based on testing and bug reports it appears that Figma's default mask mode is \`ALPHA\` and when set, its omitted from the figma model. This means we need to tweak our \`get\` default to match

### Figma
![CleanShot 2025-07-04 at 15 23 11@2x](https://github.com/user-attachments/assets/ea85644c-4de2-4129-9834-7cf7c6ef3d31)


### Sketch
![CleanShot 2025-07-04 at 15 23 45@2x](https://github.com/user-attachments/assets/66f15c58-8c03-46de-9220-6b98ca7d6845)
