### PR TITLE
Add support for progressive layer blurs

### DIFF
--- a/src/sketchformat/style.py
+++ b/src/sketchformat/style.py
@@ -127,7 +127,7 @@ class Gradient:
     _class: str = field(default="gradient")
     gradientType: GradientType = GradientType.LINEAR
     elipseLength: float = 0
-    from_: Point = field(default_factory=lambda: Point(0.5, 1))
+    from_: InitVar[Point] = Point(0.5, 0)
     to: Point = field(default_factory=lambda: Point(0.5, 1))
     stops: List[GradientStop] = field(
         default_factory=lambda: [
@@ -135,6 +135,9 @@ class Gradient:
             GradientStop(color=Color.Black(), position=1),
         ]
     )
+
+    def __post_init__(self, from_):
+        setattr(self, "from", from_)
 
     @staticmethod
     def Linear(from_: Point, to: Point, stops: List[GradientStop]) -> "Gradient":

--- a/src/sketchformat/style.py
+++ b/src/sketchformat/style.py
@@ -127,7 +127,7 @@ class Gradient:
     _class: str = field(default="gradient")
     gradientType: GradientType = GradientType.LINEAR
     elipseLength: float = 0
-    from_: InitVar[Point] = Point(0.5, 0)
+    from_: Point = field(default_factory=lambda: Point(0.5, 1))
     to: Point = field(default_factory=lambda: Point(0.5, 1))
     stops: List[GradientStop] = field(
         default_factory=lambda: [
@@ -135,9 +135,6 @@ class Gradient:
             GradientStop(color=Color.Black(), position=1),
         ]
     )
-
-    def __post_init__(self, from_):
-        setattr(self, "from", from_)
 
     @staticmethod
     def Linear(from_: Point, to: Point, stops: List[GradientStop]) -> "Gradient":
@@ -285,6 +282,9 @@ class Blur:
     saturation: float = 1
     brightness: float = 1
     type: BlurType = BlurType.GAUSSIAN
+    # Progressive blur support
+    isProgressive: bool = False
+    gradient: Optional[Gradient] = None
     # Glass effect support
     isCustomGlass: bool = False
     distortion: float = 0

--- a/tests/converter/test_style.py
+++ b/tests/converter/test_style.py
@@ -82,7 +82,7 @@ class TestConvertFill:
         assert fill.isEnabled
         assert fill.gradient.gradientType == GradientType.LINEAR
         assert fill.gradient.to == Point(0.7071135624381276, 0.1414227124876255)
-        assert getattr(fill.gradient, "from") == Point(0, 0.8485362749257531)
+        assert fill.gradient.from_ == Point(0, 0.8485362749257531)
 
         assert fill.gradient.stops == [
             GradientStop(color=SKETCH_COLOR[0], position=0),
@@ -108,7 +108,7 @@ class TestConvertFill:
         assert fill.isEnabled
         assert fill.gradient.gradientType == GradientType.RADIAL
         assert fill.gradient.to == Point(0.7071135624381276, 0.1414227124876255)
-        assert getattr(fill.gradient, "from") == Point(0.3535567812190638, 0.4949794937066893)
+        assert fill.gradient.from_ == Point(0.3535567812190638, 0.4949794937066893)
         assert fill.gradient.elipseLength == 1
         assert fill.gradient.stops == [
             GradientStop(color=SKETCH_COLOR[0], position=0),
@@ -225,7 +225,7 @@ class TestConvertBorder:
         assert border.isEnabled
         assert border.gradient.gradientType == GradientType.RADIAL
         assert border.gradient.to == Point(0.5, -1.5)
-        assert getattr(border.gradient, "from") == Point(0, -1.5)
+        assert border.gradient.from_ == Point(0, -1.5)
 
         # (width+2*stroke) / (height+2*stroke)
         assert border.gradient.elipseLength == 2 / 52

--- a/tests/converter/test_style.py
+++ b/tests/converter/test_style.py
@@ -82,7 +82,7 @@ class TestConvertFill:
         assert fill.isEnabled
         assert fill.gradient.gradientType == GradientType.LINEAR
         assert fill.gradient.to == Point(0.7071135624381276, 0.1414227124876255)
-        assert fill.gradient.from_ == Point(0, 0.8485362749257531)
+        assert getattr(fill.gradient, "from") == Point(0, 0.8485362749257531)
 
         assert fill.gradient.stops == [
             GradientStop(color=SKETCH_COLOR[0], position=0),
@@ -108,7 +108,7 @@ class TestConvertFill:
         assert fill.isEnabled
         assert fill.gradient.gradientType == GradientType.RADIAL
         assert fill.gradient.to == Point(0.7071135624381276, 0.1414227124876255)
-        assert fill.gradient.from_ == Point(0.3535567812190638, 0.4949794937066893)
+        assert getattr(fill.gradient, "from") == Point(0.3535567812190638, 0.4949794937066893)
         assert fill.gradient.elipseLength == 1
         assert fill.gradient.stops == [
             GradientStop(color=SKETCH_COLOR[0], position=0),
@@ -225,7 +225,7 @@ class TestConvertBorder:
         assert border.isEnabled
         assert border.gradient.gradientType == GradientType.RADIAL
         assert border.gradient.to == Point(0.5, -1.5)
-        assert border.gradient.from_ == Point(0, -1.5)
+        assert getattr(border.gradient, "from") == Point(0, -1.5)
 
         # (width+2*stroke) / (height+2*stroke)
         assert border.gradient.elipseLength == 2 / 52


### PR DESCRIPTION
Both Figma and Sketch now support "progressive blurs". We need to convert from Figma's simple progressive blur model to Sketch's gradient-backed progressive blur model.

## Results

### Figma 
<img width="3186" height="1922" alt="CleanShot 2025-08-19 at 10 21 44@2x" src="https://github.com/user-attachments/assets/39c9a85b-5296-49f0-9f68-37c33669785b" />


### Sketch
<img width="2922" height="1576" alt="CleanShot 2025-08-19 at 10 21 12@2x" src="https://github.com/user-attachments/assets/311b98c8-8dc2-4423-82c8-caff5adef3c9" />

