### PR TITLE
Import Figma variants as Sketch VariantSets

### DIFF
--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -93,6 +93,9 @@ class Context:
     def used_fonts(self) -> Dict[Tuple[str, str], Tuple[IO[bytes], str]]:
         return self._used_fonts
 
+    def is_component_page_symbol(self, sid: Sequence[int]) -> bool:
+        return sid in self._component_symbols
+
     def find_symbol(self, sid: Sequence[int]) -> dict:
         symbol = self.fig_node(sid)
         sid = symbol["guid"]

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -1,5 +1,5 @@
 import math
-from . import base, group, prototype, rectangle, layout
+from . import base, group, prototype, rectangle, layout, symbol
 from converter import utils
 from sketchformat.layer_group import (
     ClippingBehavior,
@@ -38,6 +38,9 @@ def post_process_frame(fig_frame: dict, sketch_frame: Frame) -> Frame:
 
     if utils.has_auto_layout(fig_frame):
         sketch_frame = layout.post_process_group_layout(fig_frame, sketch_frame)
+
+    if fig_frame.get("isStateGroup", False):
+        sketch_frame.variantProperties = symbol.build_variant_properties(fig_frame)
 
     return sketch_frame
 

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -40,6 +40,7 @@ def post_process_frame(fig_frame: dict, sketch_frame: Frame) -> Frame:
         sketch_frame = layout.post_process_group_layout(fig_frame, sketch_frame)
 
     if fig_frame.get("isStateGroup", False):
+        sketch_frame.groupBehavior = 3
         sketch_frame.variantProperties = symbol.build_variant_properties(fig_frame)
 
     return sketch_frame

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -43,17 +43,18 @@ def convert(fig_symbol):
     return master
 
 
-def move_to_symbols_page(fig_symbol, sketch_symbol):
-    # After the entire symbol is converted, move it to the Symbols page
-    context.add_symbol(sketch_symbol)
-
+def move_to_symbols_page_if_needed(fig_symbol, sketch_symbol):
     # Figma stores its stack children in bottom up order, but Sketch uses top down
     if utils.has_auto_layout(fig_symbol):
         sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)
 
-    # Since we put the Symbol in a different page in Sketch, leave an instance where the
-    # master used to be
-    return instance.master_instance(fig_symbol)
+    if context.is_component_page_symbol(fig_symbol["guid"]):
+        # Symbol lives on Figma's hidden components page — move it to the Symbols page
+        context.add_symbol(sketch_symbol)
+        return instance.master_instance(fig_symbol)
+
+    # Symbol lives on a visible page — keep it in place
+    return sketch_symbol
 
 
 def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -31,11 +31,11 @@ def convert(fig_symbol):
     # Keep the base ID as the symbol reference, create a new one for the container
     master.do_objectID = utils.gen_object_id(fig_symbol["guid"], b"symbol_master")
 
-    # Use better names for variants if possible
     try:
         parent = context.fig_node(fig_symbol["parent"]["guid"])
         if parent and parent.get("isStateGroup", False):
             master.name = symbol_variant_name(parent, fig_symbol)
+            master.variantSpecs = build_variant_specs(parent["guid"], fig_symbol)
 
     except Exception as e:
         print(e)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -2,7 +2,7 @@ from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 # LAYOUT_AXIS = {
 #     "NONE": None,
@@ -84,7 +84,7 @@ def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
 
 
 def _variant_properties_from_orders(
-    parent_guid, orders: list
+    parent_guid: Sequence[int], orders: list
 ) -> List[VariantProperty]:
     properties = []
     for order in orders:
@@ -137,7 +137,8 @@ def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProp
     return properties
 
 
-def build_variant_specs(parent_guid, fig_symbol: dict) -> Optional[Dict[str, str]]:
+def build_variant_specs(parent_guid: Sequence[int], fig_symbol: dict) -> Optional[Dict[str, str]]:
+    """Map VariantProperty objectID → VariantPropertyValue objectID for this symbol."""
     pairs = parse_variant_values(fig_symbol["name"])
     if not pairs:
         utils.log_conversion_warning("VAR002", fig_symbol)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -2,6 +2,7 @@ from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
+from typing import Dict, List, Optional, Tuple
 
 # LAYOUT_AXIS = {
 #     "NONE": None,
@@ -55,7 +56,101 @@ def move_to_symbols_page(fig_symbol, sketch_symbol):
     return instance.master_instance(fig_symbol)
 
 
+def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:
+    pairs = []
+    for part in symbol_name.split(","):
+        part = part.strip()
+        if "=" not in part:
+            continue
+        prop, _, val = part.partition("=")
+        pairs.append((prop.strip(), val.strip()))
+    return pairs
+
+
 def symbol_variant_name(parent, symbol):
-    property_values = [x.strip().split("=")[1] for x in symbol["name"].split(",")]
-    ordered_values = [parent["name"]] + property_values
+    pairs = parse_variant_values(symbol["name"])
+    ordered_values = [parent["name"]] + [val for _, val in pairs]
     return "/".join(ordered_values)
+
+
+def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
+    parent_guid = parent["guid"]
+    orders = parent.get("stateGroupPropertyValueOrders", [])
+
+    if orders:
+        return _variant_properties_from_orders(parent_guid, orders)
+
+    return _variant_properties_from_children(parent)
+
+
+def _variant_properties_from_orders(
+    parent_guid, orders: list
+) -> List[VariantProperty]:
+    properties = []
+    for order in orders:
+        prop_name = order["property"]
+        prop_id = utils.gen_object_id(
+            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
+        )
+        values = []
+        for val_name in order["values"]:
+            val_id = utils.gen_object_id(
+                parent_guid,
+                b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
+            )
+            values.append(VariantPropertyValue(do_objectID=val_id, name=val_name))
+        properties.append(VariantProperty(do_objectID=prop_id, name=prop_name, values=values))
+    return properties
+
+
+def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProperty]]:
+    from collections import OrderedDict
+
+    prop_values: OrderedDict[str, list] = OrderedDict()
+    for child in parent.get("children", []):
+        if child.get("type") != "SYMBOL":
+            continue
+        for prop_name, val_name in parse_variant_values(child["name"]):
+            if prop_name not in prop_values:
+                prop_values[prop_name] = []
+            if val_name not in prop_values[prop_name]:
+                prop_values[prop_name].append(val_name)
+
+    if not prop_values:
+        utils.log_conversion_warning("VAR001", parent)
+        return None
+
+    parent_guid = parent["guid"]
+    properties = []
+    for prop_name, val_names in prop_values.items():
+        prop_id = utils.gen_object_id(
+            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
+        )
+        values = []
+        for val_name in val_names:
+            val_id = utils.gen_object_id(
+                parent_guid,
+                b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
+            )
+            values.append(VariantPropertyValue(do_objectID=val_id, name=val_name))
+        properties.append(VariantProperty(do_objectID=prop_id, name=prop_name, values=values))
+    return properties
+
+
+def build_variant_specs(parent_guid, fig_symbol: dict) -> Optional[Dict[str, str]]:
+    pairs = parse_variant_values(fig_symbol["name"])
+    if not pairs:
+        utils.log_conversion_warning("VAR002", fig_symbol)
+        return None
+
+    specs = {}
+    for prop_name, val_name in pairs:
+        prop_id = utils.gen_object_id(
+            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
+        )
+        val_id = utils.gen_object_id(
+            parent_guid,
+            b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
+        )
+        specs[prop_id] = val_id
+    return specs

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -48,7 +48,7 @@ POST_PROCESSING: Dict[str, Callable[[dict, Any], AbstractLayer]] = {
     "FRAME": frame.post_process_frame,
     "GROUP": group.post_process_frame,
     "BOOLEAN_OPERATION": shape_group.post_process,
-    "SYMBOL": symbol.move_to_symbols_page,
+    "SYMBOL": symbol.move_to_symbols_page_if_needed,
     "INSTANCE": instance.post_process,
 }
 

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -109,6 +109,8 @@ WARNING_MESSAGES = {
     "LAY001": "is an unsupported layer type, it will not be converted",
     "NOD001": "node could not be found",
     "STK001": "has a stack layout with last on top ordering and a child which ignores the layout. This layout will not be converted.",
+    "VAR001": "is a component set but has no parseable variant properties. Variant data will not be converted",
+    "VAR002": "is a variant but its name could not be parsed for variant values. Its variantSpecs will be empty",
 }
 
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -2,7 +2,7 @@ from .layer_common import *
 from .common import WindingRule
 from .prototype import *
 from enum import IntEnum
-from typing import Any, Optional, List
+from typing import Any, Dict, Optional, List
 
 
 class LayoutAxis(IntEnum):
@@ -81,6 +81,21 @@ class InferredGroupLayout:
 
 
 @dataclass(kw_only=True)
+class VariantPropertyValue:
+    _class: str = field(default="variantPropertyValue")
+    do_objectID: str
+    name: str
+
+
+@dataclass(kw_only=True)
+class VariantProperty:
+    _class: str = field(default="variantProperty")
+    do_objectID: str
+    name: str
+    values: List[VariantPropertyValue] = field(default_factory=list)
+
+
+@dataclass(kw_only=True)
 class AbstractLayerGroup(AbstractStyledLayer):
     hasClickThrough: bool = False
     groupBehavior: int = 0
@@ -94,6 +109,7 @@ class AbstractLayerGroup(AbstractStyledLayer):
     bottomPadding: float = 0
     paddingSelection: PaddingSelection = PaddingSelection.UNIFORM
     layers: List[AbstractLayer] = field(default_factory=list)
+    variantProperties: Optional[List[VariantProperty]] = None
 
 
 @dataclass(kw_only=True)
@@ -150,6 +166,7 @@ class SymbolMaster(Frame):
     includeBackgroundColorInInstance: bool = True
     symbolID: str
     overrideProperties: List[OverrideProperty] = field(default_factory=list)
+    variantSpecs: Optional[Dict[str, str]] = None
 
 
 @dataclass(kw_only=True)

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -50,15 +50,13 @@ def empty_context(monkeypatch):
 
 
 def test_rounded_corners(no_prototyping, empty_context):
-    instance = tree.convert_node(
+    master = tree.convert_node(
         {**FIG_SYMBOL, "rectangleTopLeftCornerRadius": 5},
         "",
     )
 
-    symbol = context.symbols_page.layers[0]
-
-    assert instance.symbolID == symbol.symbolID
-    assert symbol.style.corners.radii[0] == 5
+    assert master._class == "symbolMaster"
+    assert master.style.corners.radii[0] == 5
 
 
 def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
@@ -80,8 +78,8 @@ def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
         "",
     )
 
-    symbol = context.symbols_page.layers[0]
-    assert symbol.style.shadows == [
+    assert g._class == "symbolMaster"
+    assert g.style.shadows == [
         Shadow(
             blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1], isInnerShadow=True
         )
@@ -209,17 +207,15 @@ def _collect_ids(node, id_map):
 
 
 def test_variant_specs_on_symbol_master(no_prototyping, component_set_context):
-    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    master = context.symbols_page.layers[0]
     assert master.variantSpecs is not None
     assert len(master.variantSpecs) == 2
 
 
 def test_variant_ids_match(no_prototyping, component_set_context):
-    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    master = context.symbols_page.layers[0]
     props = symbol.build_variant_properties(FIG_COMPONENT_SET)
 
     prop_ids = {p.do_objectID for p in props}
@@ -231,16 +227,14 @@ def test_variant_ids_match(no_prototyping, component_set_context):
 
 
 def test_variant_name_preserved(no_prototyping, component_set_context):
-    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    master = context.symbols_page.layers[0]
     assert master.name == "Button/Small/Default"
 
 
 def test_non_variant_symbol_unaffected(no_prototyping, empty_context):
-    tree.convert_node({**FIG_SYMBOL}, "")
+    master = tree.convert_node({**FIG_SYMBOL}, "")
 
-    master = context.symbols_page.layers[0]
     assert master.variantSpecs is None
 
 

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -241,7 +241,15 @@ def test_non_variant_symbol_unaffected(no_prototyping, empty_context):
 def test_variant_properties_on_frame(no_prototyping, component_set_context):
     sketch_frame = tree.convert_node(FIG_COMPONENT_SET, "CANVAS")
 
+    assert sketch_frame.groupBehavior == 3
     assert sketch_frame.variantProperties is not None
     assert len(sketch_frame.variantProperties) == 2
     assert sketch_frame.variantProperties[0].name == "Size"
     assert sketch_frame.variantProperties[1].name == "State"
+
+
+def test_non_variant_frame_keeps_default_group_behavior(no_prototyping, empty_context):
+    fig_frame = {**FIG_BASE, "type": "FRAME", "resizeToFit": False, "children": []}
+    sketch_frame = tree.convert_node(fig_frame, "CANVAS")
+
+    assert sketch_frame.groupBehavior == 1

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -1,5 +1,6 @@
 from .base import *
-from converter import tree, symbol
+from converter import tree, symbol, utils
+from sketchformat.layer_group import VariantProperty, VariantPropertyValue
 from sketchformat.layer_shape import Rectangle
 import pytest
 from converter.context import context
@@ -8,6 +9,38 @@ FIG_SYMBOL = {
     **FIG_BASE,
     "type": "SYMBOL",
     "children": [],
+}
+
+FIG_COMPONENT_SET = {
+    **FIG_BASE,
+    "type": "FRAME",
+    "name": "Button",
+    "guid": (10, 10),
+    "isStateGroup": True,
+    "resizeToFit": False,
+    "stateGroupPropertyValueOrders": [
+        {"property": "Size", "values": ["Small", "Large"]},
+        {"property": "State", "values": ["Default", "Hover"]},
+    ],
+    "children": [
+        {
+            **FIG_BASE,
+            "type": "SYMBOL",
+            "name": "Size=Small, State=Default",
+            "guid": (11, 11),
+            "children": [],
+            "parent": {"guid": (10, 10)},
+        },
+        {
+            **FIG_BASE,
+            "type": "SYMBOL",
+            "name": "Size=Large, State=Hover",
+            "guid": (12, 12),
+            "children": [],
+            "parent": {"guid": (10, 10)},
+        },
+    ],
+    "parent": {"guid": (1, 1)},
 }
 
 
@@ -70,3 +103,151 @@ def test_variant_name():
         "parent": {"guid": (22, 22)},
     }
     assert symbol.symbol_variant_name(variants, variants["children"][0]) == "Starch/Potato/Another"
+
+
+# --- parse_variant_values ---
+
+
+def test_parse_variant_values():
+    assert symbol.parse_variant_values("Size=Small, State=Default") == [
+        ("Size", "Small"),
+        ("State", "Default"),
+    ]
+
+
+def test_parse_variant_values_single():
+    assert symbol.parse_variant_values("Tinted=True") == [("Tinted", "True")]
+
+
+def test_parse_variant_values_malformed():
+    assert symbol.parse_variant_values("NoEquals") == []
+
+
+def test_parse_variant_values_empty_value():
+    assert symbol.parse_variant_values("A=1, B=, C=3") == [("A", "1"), ("B", ""), ("C", "3")]
+
+
+# --- build_variant_properties ---
+
+
+def test_build_variant_properties():
+    props = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    assert len(props) == 2
+    assert props[0].name == "Size"
+    assert [v.name for v in props[0].values] == ["Small", "Large"]
+    assert props[1].name == "State"
+    assert [v.name for v in props[1].values] == ["Default", "Hover"]
+
+
+def test_build_variant_properties_ids_are_deterministic():
+    props_a = symbol.build_variant_properties(FIG_COMPONENT_SET)
+    props_b = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    assert props_a[0].do_objectID == props_b[0].do_objectID
+    assert props_a[0].values[0].do_objectID == props_b[0].values[0].do_objectID
+
+
+def test_build_variant_properties_fallback(warnings):
+    parent = {
+        **FIG_BASE,
+        "type": "FRAME",
+        "name": "Fallback",
+        "guid": (20, 20),
+        "isStateGroup": True,
+        "children": [
+            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Red, Size=Big", "guid": (21, 21)},
+            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Blue, Size=Small", "guid": (22, 22)},
+        ],
+    }
+    props = symbol.build_variant_properties(parent)
+
+    assert len(props) == 2
+    assert props[0].name == "Color"
+    assert [v.name for v in props[0].values] == ["Red", "Blue"]
+    assert props[1].name == "Size"
+    assert [v.name for v in props[1].values] == ["Big", "Small"]
+
+
+def test_build_variant_properties_fallback_no_children(warnings):
+    parent = {
+        **FIG_BASE,
+        "type": "FRAME",
+        "name": "Empty",
+        "guid": (30, 30),
+        "isStateGroup": True,
+        "children": [],
+    }
+    assert symbol.build_variant_properties(parent) is None
+    warnings.assert_called_with("VAR001", parent)
+
+
+# --- Full pipeline: variant data on converted layers ---
+
+
+@pytest.fixture
+def component_set_context(monkeypatch):
+    page = {
+        **FIG_BASE,
+        "type": "CANVAS",
+        "name": "Page",
+        "guid": (1, 1),
+        "children": [FIG_COMPONENT_SET],
+        "parent": {"guid": (0, 0)},
+        "backgroundEnabled": False,
+        "backgrounds": [],
+    }
+    id_map = {}
+    _collect_ids(page, id_map)
+    context.init(None, id_map, "DISPLAY_P3")
+
+
+def _collect_ids(node, id_map):
+    id_map[tuple(node["guid"])] = node
+    for child in node.get("children", []):
+        _collect_ids(child, id_map)
+
+
+def test_variant_specs_on_symbol_master(no_prototyping, component_set_context):
+    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+
+    master = context.symbols_page.layers[0]
+    assert master.variantSpecs is not None
+    assert len(master.variantSpecs) == 2
+
+
+def test_variant_ids_match(no_prototyping, component_set_context):
+    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+
+    master = context.symbols_page.layers[0]
+    props = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    prop_ids = {p.do_objectID for p in props}
+    val_ids = {v.do_objectID for p in props for v in p.values}
+
+    for prop_id, val_id in master.variantSpecs.items():
+        assert prop_id in prop_ids
+        assert val_id in val_ids
+
+
+def test_variant_name_preserved(no_prototyping, component_set_context):
+    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+
+    master = context.symbols_page.layers[0]
+    assert master.name == "Button/Small/Default"
+
+
+def test_non_variant_symbol_unaffected(no_prototyping, empty_context):
+    tree.convert_node({**FIG_SYMBOL}, "")
+
+    master = context.symbols_page.layers[0]
+    assert master.variantSpecs is None
+
+
+def test_variant_properties_on_frame(no_prototyping, component_set_context):
+    sketch_frame = tree.convert_node(FIG_COMPONENT_SET, "CANVAS")
+
+    assert sketch_frame.variantProperties is not None
+    assert len(sketch_frame.variantProperties) == 2
+    assert sketch_frame.variantProperties[0].name == "Size"
+    assert sketch_frame.variantProperties[1].name == "State"


### PR DESCRIPTION
## Summary

- Add `VariantProperty` and `VariantPropertyValue` dataclasses to `sketchformat`, matching Sketch's new variant model
- Add `variantProperties` to `AbstractLayerGroup` and `variantSpecs` to `SymbolMaster`
- Convert Figma component sets (`isStateGroup: true`) into Sketch groups with populated `variantProperties`, and set `variantSpecs` on each child SymbolMaster
- Deterministic ID generation for variant entities via `gen_object_id` with property/value name suffixes
- Fallback to scanning child names when `stateGroupPropertyValueOrders` is missing