### PR TITLE
Keep symbols on visible pages

### DIFF
--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -93,6 +93,9 @@ class Context:
     def used_fonts(self) -> Dict[Tuple[str, str], Tuple[IO[bytes], str]]:
         return self._used_fonts
 
+    def is_component_page_symbol(self, sid: Sequence[int]) -> bool:
+        return sid in self._component_symbols
+
     def find_symbol(self, sid: Sequence[int]) -> dict:
         symbol = self.fig_node(sid)
         sid = symbol["guid"]

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -42,7 +42,15 @@ def convert(fig_symbol):
     return master
 
 
-def move_to_symbols_page_if_needed(fig_symbol, sketch_symbol):
+def post_process_symbol(fig_symbol, sketch_symbol):
+    """Finalize a converted symbol and decide where its master should live.
+
+    Symbols from Figma's hidden components page are moved to Sketch's Symbols page
+    and replaced at the original site with an instance. Symbols from visible Figma
+    pages are returned unchanged so they stay in place. The hidden-page check is
+    based on the component symbol IDs collected when the conversion context is
+    initialized.
+    """
     # Figma stores its stack children in bottom up order, but Sketch uses top down
     if utils.has_auto_layout(fig_symbol):
         sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -42,17 +42,18 @@ def convert(fig_symbol):
     return master
 
 
-def move_to_symbols_page(fig_symbol, sketch_symbol):
-    # After the entire symbol is converted, move it to the Symbols page
-    context.add_symbol(sketch_symbol)
-
+def move_to_symbols_page_if_needed(fig_symbol, sketch_symbol):
     # Figma stores its stack children in bottom up order, but Sketch uses top down
     if utils.has_auto_layout(fig_symbol):
         sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)
 
-    # Since we put the Symbol in a different page in Sketch, leave an instance where the
-    # master used to be
-    return instance.master_instance(fig_symbol)
+    if context.is_component_page_symbol(fig_symbol["guid"]):
+        # Symbol lives on Figma's hidden components page — move it to the Symbols page
+        context.add_symbol(sketch_symbol)
+        return instance.master_instance(fig_symbol)
+
+    # Symbol lives on a visible page — keep it in place
+    return sketch_symbol
 
 
 def symbol_variant_name(parent, symbol):

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -48,7 +48,7 @@ POST_PROCESSING: Dict[str, Callable[[dict, Any], AbstractLayer]] = {
     "FRAME": frame.post_process_frame,
     "GROUP": group.post_process_frame,
     "BOOLEAN_OPERATION": shape_group.post_process,
-    "SYMBOL": symbol.move_to_symbols_page_if_needed,
+    "SYMBOL": symbol.post_process_symbol,
     "INSTANCE": instance.post_process,
 }
 

--- a/src/converter/tree.py
+++ b/src/converter/tree.py
@@ -48,7 +48,7 @@ POST_PROCESSING: Dict[str, Callable[[dict, Any], AbstractLayer]] = {
     "FRAME": frame.post_process_frame,
     "GROUP": group.post_process_frame,
     "BOOLEAN_OPERATION": shape_group.post_process,
-    "SYMBOL": symbol.move_to_symbols_page,
+    "SYMBOL": symbol.move_to_symbols_page_if_needed,
     "INSTANCE": instance.post_process,
 }
 

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -17,15 +17,13 @@ def empty_context(monkeypatch):
 
 
 def test_rounded_corners(no_prototyping, empty_context):
-    instance = tree.convert_node(
+    master = tree.convert_node(
         {**FIG_SYMBOL, "rectangleTopLeftCornerRadius": 5},
         "",
     )
 
-    symbol = context.symbols_page.layers[0]
-
-    assert instance.symbolID == symbol.symbolID
-    assert symbol.style.corners.radii[0] == 5
+    assert master._class == "symbolMaster"
+    assert master.style.corners.radii[0] == 5
 
 
 def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
@@ -47,8 +45,8 @@ def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
         "",
     )
 
-    symbol = context.symbols_page.layers[0]
-    assert symbol.style.shadows == [
+    assert g._class == "symbolMaster"
+    assert g.style.shadows == [
         Shadow(
             blurRadius=4, offsetX=1, offsetY=3, spread=0, color=SKETCH_COLOR[1], isInnerShadow=True
         )

--- a/tests/integration/test_structure.py
+++ b/tests/integration/test_structure.py
@@ -22,7 +22,6 @@ def test_user(sketch_doc):
     with sketch_doc.open("user.json") as user_json:
         user = json.load(user_json)
         assert "8F292FCA-49C0-4E31-957E-93FB2D1A7231" in user
-        assert "A4E5259A-9CE6-49D9-B4A1-A8062C205347" in user
         assert user["document"] == {
             "expandedSymbolPathsInSidebar": [],
             "expandedTextStylePathsInPopover": [],
@@ -44,10 +43,6 @@ def test_meta(sketch_doc):
                         "60CDCBD8-345A-4796-804B-C6A97C9C0587": {"name": "Groups"},
                         "B4AC371F-D026-411F-985B-F92A86A928F6": {"name": "Symbols and images"},
                     },
-                },
-                "A4E5259A-9CE6-49D9-B4A1-A8062C205347": {
-                    "name": "Symbols",
-                    "artboards": {"FA7E522B-5FF7-4393-AD4D-44C2A82CF837": {"name": "Component 1"}},
                 },
             },
             "version": 187,
@@ -81,12 +76,7 @@ def test_document(sketch_doc):
                 "_class": "MSJSONFileReference",
                 "_ref_class": "MSImmutablePage",
                 "_ref": "pages/8F292FCA-49C0-4E31-957E-93FB2D1A7231",
-            },
-            {
-                "_class": "MSJSONFileReference",
-                "_ref_class": "MSImmutablePage",
-                "_ref": "pages/A4E5259A-9CE6-49D9-B4A1-A8062C205347",
-            },
+            }
         ]
         assert doc["fontReferences"] == [
             {
@@ -154,9 +144,10 @@ def test_page(sketch_doc):
         assert syms["name"] == "Symbols and images"
         i1, i2, i3, jpg, png, svg = syms["layers"]
 
-        # Master instance
-        assert i1["_class"] == "symbolInstance"
-        assert i1["overrideValues"] == []
+        # Visible symbol master
+        assert i1["_class"] == "symbolMaster"
+        assert i1["name"] == "Component 1"
+        assert len(i1["layers"]) == 2
 
         # Instance with text override
         assert i2["_class"] == "symbolInstance"
@@ -202,17 +193,8 @@ def test_page(sketch_doc):
             assert l["_class"] in ["shapePath", "shapeGroup"]
 
 
-def test_symbols_page(sketch_doc):
-    with sketch_doc.open("pages/A4E5259A-9CE6-49D9-B4A1-A8062C205347.json") as page_json:
-        page = json.load(page_json)
-        assert page["name"] == "Symbols"
-        assert len(page["layers"]) == 1
-
-        symbol = page["layers"][0]
-        assert symbol["name"] == "Component 1"
-        assert symbol["_class"] == "symbolMaster"
-
-        assert len(symbol["layers"]) == 2
+def test_visible_symbols_do_not_create_symbols_page(sketch_doc):
+    assert "pages/A4E5259A-9CE6-49D9-B4A1-A8062C205347.json" not in sketch_doc.namelist()
 
 
 def test_files(sketch_doc):
@@ -221,7 +203,6 @@ def test_files(sketch_doc):
         "images/616d10a80971e08c6b43a164746afac1972c7ccc.png",
         "images/92e4d5e0c24ffd632c3db3264e62cc907c2f5e29",
         "pages/8F292FCA-49C0-4E31-957E-93FB2D1A7231.json",
-        "pages/A4E5259A-9CE6-49D9-B4A1-A8062C205347.json",
         "fonts/f0b7cea3f659e72f3ea9285a4d60712878169c07",
         "document.json",
         "user.json",


### PR DESCRIPTION
## Summary

- Keep symbol masters that appear on visible Figma pages in place instead of always moving them to Sketch's Symbols page.
- Continue moving symbols from Figma's hidden components page to Sketch's Symbols page, replacing the original location with an instance.
- Make that decision explicit in `post_process_symbol`, based on the component symbol IDs collected when the conversion context is initialized.
- Update the structure integration expectations for visible-page symbols.