### PR TITLE
Use structured properties to parse variant properties and specs

### DIFF
--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -66,24 +66,24 @@ def post_process_symbol(fig_symbol, sketch_symbol):
 
 
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
-    orders = parent.get("stateGroupPropertyValueOrders", [])
-    if not orders:
+    orderedPropertyValues = parent.get("stateGroupPropertyValueOrders", [])
+    if not orderedPropertyValues:
         utils.log_conversion_warning("VAR001", parent)
         return None
-    return _variant_properties_from_orders(parent["guid"], orders)
+    return _variant_properties_from_orders(parent["guid"], orderedPropertyValues)
 
 
 def _variant_properties_from_orders(
-    parent_guid: Sequence[int], orders: list
+    parent_guid: Sequence[int], orderedPropertyValues: list
 ) -> List[VariantProperty]:
     properties = []
-    for order in orders:
-        prop_name = order["property"]
+    for orderedPropertyValue in orderedPropertyValues:
+        prop_name = orderedPropertyValue["property"]
         prop_id = utils.gen_object_id(
             parent_guid, b"variant_property:" + prop_name.encode("utf-8")
         )
         values = []
-        for val_name in order["values"]:
+        for val_name in orderedPropertyValue["values"]:
             val_id = utils.gen_object_id(
                 parent_guid,
                 b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -46,18 +46,18 @@ def convert(fig_symbol):
 def post_process_symbol(fig_symbol, sketch_symbol):
     """Finalize a converted symbol and decide where its master should live.
 
-    Symbols from Figma's hidden components page are moved to Sketch's Symbols page
-    and replaced at the original site with an instance. Symbols from visible Figma
+    Symbols from .fig format's hidden components page are moved to Sketch's Symbols page
+    and replaced at the original site with an instance. Symbols from visible .fig
     pages are returned unchanged so they stay in place. The hidden-page check is
-    based on the component symbol IDs collected when the conversion context is
+    based on the component symbol IDs collected when the conversion context iss
     initialized.
     """
-    # Figma stores its stack children in bottom up order, but Sketch uses top down
+    # .fig stores its stack children in bottom up order, but Sketch uses top down
     if utils.has_auto_layout(fig_symbol):
         sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)
 
     if context.is_component_page_symbol(fig_symbol["guid"]):
-        # Symbol lives on Figma's hidden components page — move it to the Symbols page
+        # Symbol lives on .fig's hidden components page — move it to the Symbols page
         context.add_symbol(sketch_symbol)
         return instance.master_instance(fig_symbol)
 
@@ -68,7 +68,7 @@ def post_process_symbol(fig_symbol, sketch_symbol):
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
     """Build VariantProperty list from stateGroupPropertyValueOrders on the component set.
 
-    The order of properties and their values is preserved from Figma's ordering,
+    The order of properties and their values is preserved from .fig format ordering,
     which controls how variants are presented in the Sketch inspector.
     """
     orderedPropertyValues = parent.get("stateGroupPropertyValueOrders", [])

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -2,7 +2,7 @@ from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Tuple
 
 # LAYOUT_AXIS = {
 #     "NONE": None,
@@ -70,12 +70,7 @@ def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
     if not orderedPropertyValues:
         utils.log_conversion_warning("VAR001", parent)
         return None
-    return _variant_properties_from_orders(parent["guid"], orderedPropertyValues)
-
-
-def _variant_properties_from_orders(
-    parent_guid: Sequence[int], orderedPropertyValues: list
-) -> List[VariantProperty]:
+    parent_guid = parent["guid"]
     properties = []
     for orderedPropertyValue in orderedPropertyValues:
         prop_name = orderedPropertyValue["property"]

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -66,6 +66,11 @@ def post_process_symbol(fig_symbol, sketch_symbol):
 
 
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
+    """Build VariantProperty list from stateGroupPropertyValueOrders on the component set.
+
+    The order of properties and their values is preserved from Figma's ordering,
+    which controls how variants are presented in the Sketch inspector.
+    """
     orderedPropertyValues = parent.get("stateGroupPropertyValueOrders", [])
     if not orderedPropertyValues:
         utils.log_conversion_warning("VAR001", parent)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -65,25 +65,12 @@ def post_process_symbol(fig_symbol, sketch_symbol):
     return sketch_symbol
 
 
-def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:
-    pairs = []
-    for part in symbol_name.split(","):
-        part = part.strip()
-        if "=" not in part:
-            continue
-        prop, _, val = part.partition("=")
-        pairs.append((prop.strip(), val.strip()))
-    return pairs
-
-
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
-    parent_guid = parent["guid"]
     orders = parent.get("stateGroupPropertyValueOrders", [])
-
-    if orders:
-        return _variant_properties_from_orders(parent_guid, orders)
-
-    return _variant_properties_from_children(parent)
+    if not orders:
+        utils.log_conversion_warning("VAR001", parent)
+        return None
+    return _variant_properties_from_orders(parent["guid"], orders)
 
 
 def _variant_properties_from_orders(
@@ -106,49 +93,12 @@ def _variant_properties_from_orders(
     return properties
 
 
-def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProperty]]:
-    from collections import OrderedDict
-
-    prop_values: OrderedDict[str, list] = OrderedDict()
-    for child in parent.get("children", []):
-        if child.get("type") != "SYMBOL":
-            continue
-        for prop_name, val_name in parse_variant_values(child["name"]):
-            if prop_name not in prop_values:
-                prop_values[prop_name] = []
-            if val_name not in prop_values[prop_name]:
-                prop_values[prop_name].append(val_name)
-
-    if not prop_values:
-        utils.log_conversion_warning("VAR001", parent)
-        return None
-
-    parent_guid = parent["guid"]
-    properties = []
-    for prop_name, val_names in prop_values.items():
-        prop_id = utils.gen_object_id(
-            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
-        )
-        values = []
-        for val_name in val_names:
-            val_id = utils.gen_object_id(
-                parent_guid,
-                b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
-            )
-            values.append(VariantPropertyValue(do_objectID=val_id, name=val_name))
-        properties.append(VariantProperty(do_objectID=prop_id, name=prop_name, values=values))
-    return properties
-
-
 def build_variant_specs(parent: dict, fig_symbol: dict) -> Optional[Dict[str, str]]:
     """Map VariantProperty objectID → VariantPropertyValue objectID for this symbol."""
     parent_guid = parent["guid"]
     prop_specs = fig_symbol.get("variantPropSpecs", [])
 
-    if prop_specs:
-        pairs = _pairs_from_prop_specs(parent, prop_specs)
-    else:
-        pairs = parse_variant_values(fig_symbol["name"])
+    pairs = _pairs_from_prop_specs(parent, prop_specs)
 
     if not pairs:
         utils.log_conversion_warning("VAR002", fig_symbol)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -35,7 +35,7 @@ def convert(fig_symbol):
         parent = context.fig_node(fig_symbol["parent"]["guid"])
         if parent and parent.get("isStateGroup", False):
             master.name = fig_symbol["name"]
-            master.variantSpecs = build_variant_specs(parent["guid"], fig_symbol)
+            master.variantSpecs = build_variant_specs(parent, fig_symbol)
 
     except Exception as e:
         print(e)
@@ -140,9 +140,16 @@ def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProp
     return properties
 
 
-def build_variant_specs(parent_guid: Sequence[int], fig_symbol: dict) -> Optional[Dict[str, str]]:
+def build_variant_specs(parent: dict, fig_symbol: dict) -> Optional[Dict[str, str]]:
     """Map VariantProperty objectID → VariantPropertyValue objectID for this symbol."""
-    pairs = parse_variant_values(fig_symbol["name"])
+    parent_guid = parent["guid"]
+    prop_specs = fig_symbol.get("variantPropSpecs", [])
+
+    if prop_specs:
+        pairs = _pairs_from_prop_specs(parent, prop_specs)
+    else:
+        pairs = parse_variant_values(fig_symbol["name"])
+
     if not pairs:
         utils.log_conversion_warning("VAR002", fig_symbol)
         return None
@@ -158,3 +165,19 @@ def build_variant_specs(parent_guid: Sequence[int], fig_symbol: dict) -> Optiona
         )
         specs[prop_id] = val_id
     return specs
+
+
+def _pairs_from_prop_specs(parent: dict, prop_specs: list) -> List[Tuple[str, str]]:
+    """Resolve variantPropSpecs entries to (property_name, value) pairs via componentPropDefs."""
+    prop_defs = {
+        tuple(d["id"]): d["name"]
+        for d in parent.get("componentPropDefs", [])
+        if d.get("type") == "VARIANT"
+    }
+
+    pairs = []
+    for spec in prop_specs:
+        prop_name = prop_defs.get(tuple(spec["propDefId"]))
+        if prop_name is not None:
+            pairs.append((prop_name, spec["value"]))
+    return pairs

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -98,7 +98,7 @@ def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
     ]
 
 
-def test_variant_name_uses_figma_name_as_is(no_prototyping, empty_context):
+def test_variant_name_uses_fig_name_as_is(no_prototyping, empty_context):
     variants = {
         **FIG_BASE,
         "type": "FRAME",

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -119,28 +119,6 @@ def test_variant_name_uses_figma_name_as_is(no_prototyping, empty_context):
     assert master.name == "Property 1=Potato, Property 2=Another"
 
 
-# --- parse_variant_values ---
-
-
-def test_parse_variant_values():
-    assert symbol.parse_variant_values("Size=Small, State=Default") == [
-        ("Size", "Small"),
-        ("State", "Default"),
-    ]
-
-
-def test_parse_variant_values_single():
-    assert symbol.parse_variant_values("Tinted=True") == [("Tinted", "True")]
-
-
-def test_parse_variant_values_malformed():
-    assert symbol.parse_variant_values("NoEquals") == []
-
-
-def test_parse_variant_values_empty_value():
-    assert symbol.parse_variant_values("A=1, B=, C=3") == [("A", "1"), ("B", ""), ("C", "3")]
-
-
 # --- build_variant_properties ---
 
 
@@ -160,40 +138,6 @@ def test_build_variant_properties_ids_are_deterministic():
 
     assert props_a[0].do_objectID == props_b[0].do_objectID
     assert props_a[0].values[0].do_objectID == props_b[0].values[0].do_objectID
-
-
-def test_build_variant_properties_fallback(warnings):
-    parent = {
-        **FIG_BASE,
-        "type": "FRAME",
-        "name": "Fallback",
-        "guid": (20, 20),
-        "isStateGroup": True,
-        "children": [
-            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Red, Size=Big", "guid": (21, 21)},
-            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Blue, Size=Small", "guid": (22, 22)},
-        ],
-    }
-    props = symbol.build_variant_properties(parent)
-
-    assert len(props) == 2
-    assert props[0].name == "Color"
-    assert [v.name for v in props[0].values] == ["Red", "Blue"]
-    assert props[1].name == "Size"
-    assert [v.name for v in props[1].values] == ["Big", "Small"]
-
-
-def test_build_variant_properties_fallback_no_children(warnings):
-    parent = {
-        **FIG_BASE,
-        "type": "FRAME",
-        "name": "Empty",
-        "guid": (30, 30),
-        "isStateGroup": True,
-        "children": [],
-    }
-    assert symbol.build_variant_properties(parent) is None
-    warnings.assert_called_with("VAR001", parent)
 
 
 # --- Full pipeline: variant data on converted layers ---
@@ -279,21 +223,6 @@ def test_variant_specs_from_variantPropSpecs(no_prototyping, component_set_conte
 
     assert master.variantSpecs[size_prop_id] == small_val_id
     assert master.variantSpecs[state_prop_id] == default_val_id
-
-
-def test_variant_specs_fallback_to_name_parsing(no_prototyping, component_set_context):
-    """Without variantPropSpecs, fall back to parsing the symbol name."""
-    child = {
-        **FIG_COMPONENT_SET["children"][0],
-        "guid": (11, 11),
-    }
-    del child["variantPropSpecs"]
-    context._node_by_id[(11, 11)] = child
-
-    master = tree.convert_node(child, "FRAME")
-
-    assert master.variantSpecs is not None
-    assert len(master.variantSpecs) == 2
 
 
 def test_non_variant_frame_keeps_default_group_behavior(no_prototyping, empty_context):

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -22,6 +22,10 @@ FIG_COMPONENT_SET = {
         {"property": "Size", "values": ["Small", "Large"]},
         {"property": "State", "values": ["Default", "Hover"]},
     ],
+    "componentPropDefs": [
+        {"id": (100, 1), "name": "Size", "type": "VARIANT"},
+        {"id": (100, 2), "name": "State", "type": "VARIANT"},
+    ],
     "children": [
         {
             **FIG_BASE,
@@ -30,6 +34,10 @@ FIG_COMPONENT_SET = {
             "guid": (11, 11),
             "children": [],
             "parent": {"guid": (10, 10)},
+            "variantPropSpecs": [
+                {"propDefId": (100, 1), "value": "Small"},
+                {"propDefId": (100, 2), "value": "Default"},
+            ],
         },
         {
             **FIG_BASE,
@@ -38,6 +46,10 @@ FIG_COMPONENT_SET = {
             "guid": (12, 12),
             "children": [],
             "parent": {"guid": (10, 10)},
+            "variantPropSpecs": [
+                {"propDefId": (100, 1), "value": "Large"},
+                {"propDefId": (100, 2), "value": "Hover"},
+            ],
         },
     ],
     "parent": {"guid": (1, 1)},
@@ -250,6 +262,38 @@ def test_variant_properties_on_frame(no_prototyping, component_set_context):
     assert len(sketch_frame.variantProperties) == 2
     assert sketch_frame.variantProperties[0].name == "Size"
     assert sketch_frame.variantProperties[1].name == "State"
+
+
+def test_variant_specs_from_variantPropSpecs(no_prototyping, component_set_context):
+    """variantSpecs are built from variantPropSpecs + componentPropDefs, not name parsing."""
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    props = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    prop_by_name = {p.name: p for p in props}
+    val_by_name = {(p.name, v.name): v for p in props for v in p.values}
+
+    size_prop_id = prop_by_name["Size"].do_objectID
+    small_val_id = val_by_name[("Size", "Small")].do_objectID
+    state_prop_id = prop_by_name["State"].do_objectID
+    default_val_id = val_by_name[("State", "Default")].do_objectID
+
+    assert master.variantSpecs[size_prop_id] == small_val_id
+    assert master.variantSpecs[state_prop_id] == default_val_id
+
+
+def test_variant_specs_fallback_to_name_parsing(no_prototyping, component_set_context):
+    """Without variantPropSpecs, fall back to parsing the symbol name."""
+    child = {
+        **FIG_COMPONENT_SET["children"][0],
+        "guid": (11, 11),
+    }
+    del child["variantPropSpecs"]
+    context._node_by_id[(11, 11)] = child
+
+    master = tree.convert_node(child, "FRAME")
+
+    assert master.variantSpecs is not None
+    assert len(master.variantSpecs) == 2
 
 
 def test_non_variant_frame_keeps_default_group_behavior(no_prototyping, empty_context):


### PR DESCRIPTION
- Use .fig format's structured `variantPropSpecs` field on `SYMBOL` nodes as the primary source for building `variantSpecs`, resolving `propDefId` references through the parent's `componentPropDefs`
- Remove name-based variant props parsing fallback — variant data must come from structured .fig format fields in `stateGroupPropertyValueOrders`
- Inline and rename internal helpers for clarity (`orderedPropertyValues`)

Closes #171
Stacked on #170