### PR TITLE
Import variants

### DIFF
--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -3,10 +3,26 @@ from urllib.error import HTTPError
 from . import component, page, font
 from .errors import Fig2SketchWarning
 from sketchformat.document import Swatch
-from typing import Sequence, Tuple, Optional, Dict, IO, List
+from sketchformat.layer_common import AbstractLayer
+from sketchformat.layer_group import Page
+from typing import Sequence, Tuple, Optional, Dict, IO, List, Set
 
 
-def find_symbols(node: dict) -> List[Sequence[int]]:
+def find_node_ids(node: Optional[dict]) -> List[Sequence[int]]:
+    if not node:
+        return []
+
+    found = [node["guid"]]
+    for child in node.get("children", []):
+        found += find_node_ids(child)
+
+    return found
+
+
+def find_symbols(node: Optional[dict]) -> List[Sequence[int]]:
+    if not node:
+        return []
+
     if node["type"] == "SYMBOL":
         return [node["guid"]]
 
@@ -23,16 +39,18 @@ class Context:
     ) -> None:
         self._color_space = color_space
         self._sketch_components: Dict[Sequence[int], Swatch] = {}
-        self.symbols_page = None
+        self.symbols_page: Optional[Page] = None
         self._node_by_id = id_map
         self._used_fonts: Dict[Tuple[str, str], Tuple[IO[bytes], str]] = {}
         self._component_symbols = (
             {s: False for s in find_symbols(components_page)} if components_page else {}
         )
+        self._component_nodes: Set[Sequence[int]] = set(find_node_ids(components_page))
+        self._converted_component_sets: Set[Sequence[int]] = set()
 
         # Where to position symbols of the specified width
         # width -> (x, y)
-        self._symbol_position = {0: [0, 0]}
+        self._symbol_position: Dict[float, List[float]] = {0.0: [0.0, 0.0]}
 
     def color_space(self) -> int:
         return 2 if self._color_space == "DISPLAY_P3" else 1
@@ -52,7 +70,7 @@ class Context:
     def sketch_components(self) -> List[Swatch]:
         return list(self._sketch_components.values())
 
-    def add_symbol(self, sketch_symbol):
+    def add_symbol(self, sketch_symbol: AbstractLayer) -> None:
         if not self.symbols_page:
             self.symbols_page = page.symbols_page()
 
@@ -96,6 +114,21 @@ class Context:
     def is_component_page_symbol(self, sid: Sequence[int]) -> bool:
         return sid in self._component_symbols
 
+    def component_set_for_symbol(self, sid: Sequence[int]) -> Optional[dict]:
+        if sid not in self._component_symbols:
+            return None
+
+        symbol = self.fig_node(sid)
+        parent_id = symbol.get("parent", {}).get("guid")
+        if parent_id not in self._component_nodes:
+            return None
+
+        parent = self.fig_node(parent_id)
+        if parent.get("isStateGroup", False):
+            return parent
+
+        return None
+
     def find_symbol(self, sid: Sequence[int]) -> dict:
         symbol = self.fig_node(sid)
         sid = symbol["guid"]
@@ -104,13 +137,22 @@ class Context:
             # The symbol is in the component page and has not been converted yet, do it now
             from . import tree
 
-            tree.convert_node(symbol, "")
-            self._component_symbols[sid] = True
+            component_set = self.component_set_for_symbol(sid)
+            if component_set:
+                component_set_id = component_set["guid"]
+                if component_set_id not in self._converted_component_sets:
+                    self.add_symbol(tree.convert_node(component_set, ""))
+                    self._converted_component_sets.add(component_set_id)
+                    for child_symbol_id in find_symbols(component_set):
+                        self._component_symbols[child_symbol_id] = True
+            else:
+                tree.convert_node(symbol, "")
+                self._component_symbols[sid] = True
 
         return symbol
 
-    def _position_symbol(self, sketch_symbol):
-        # Mimics Sketch positioning algorith:
+    def _position_symbol(self, sketch_symbol: AbstractLayer) -> None:
+        # Mimics Sketch positioning algorithm:
         #   All symbols of the same width go in the same column
         #   Each different width goes into a new column
         frame = sketch_symbol.frame

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -1,5 +1,5 @@
 import math
-from . import base, group, prototype, rectangle, layout
+from . import base, group, prototype, rectangle, layout, symbol
 from converter import utils
 from sketchformat.layer_group import (
     ClippingBehavior,
@@ -38,6 +38,9 @@ def post_process_frame(fig_frame: dict, sketch_frame: Frame) -> Frame:
 
     if utils.has_auto_layout(fig_frame):
         sketch_frame = layout.post_process_group_layout(fig_frame, sketch_frame)
+
+    if fig_frame.get("isStateGroup", False):
+        sketch_frame.variantProperties = symbol.build_variant_properties(fig_frame)
 
     return sketch_frame
 

--- a/src/converter/frame.py
+++ b/src/converter/frame.py
@@ -40,6 +40,7 @@ def post_process_frame(fig_frame: dict, sketch_frame: Frame) -> Frame:
         sketch_frame = layout.post_process_group_layout(fig_frame, sketch_frame)
 
     if fig_frame.get("isStateGroup", False):
+        sketch_frame.groupBehavior = 3
         sketch_frame.variantProperties = symbol.build_variant_properties(fig_frame)
 
     return sketch_frame

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -2,7 +2,7 @@ from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 # LAYOUT_AXIS = {
 #     "NONE": None,
@@ -93,7 +93,7 @@ def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
 
 
 def _variant_properties_from_orders(
-    parent_guid, orders: list
+    parent_guid: Sequence[int], orders: list
 ) -> List[VariantProperty]:
     properties = []
     for order in orders:
@@ -146,7 +146,8 @@ def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProp
     return properties
 
 
-def build_variant_specs(parent_guid, fig_symbol: dict) -> Optional[Dict[str, str]]:
+def build_variant_specs(parent_guid: Sequence[int], fig_symbol: dict) -> Optional[Dict[str, str]]:
+    """Map VariantProperty objectID → VariantPropertyValue objectID for this symbol."""
     pairs = parse_variant_values(fig_symbol["name"])
     if not pairs:
         utils.log_conversion_warning("VAR002", fig_symbol)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -76,10 +76,12 @@ def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:
     return pairs
 
 
-def symbol_variant_name(parent, symbol):
+def symbol_variant_name(_parent, symbol):
     pairs = parse_variant_values(symbol["name"])
-    ordered_values = [parent["name"]] + [val for _, val in pairs]
-    return "/".join(ordered_values)
+    if not pairs:
+        return symbol["name"]
+
+    return ", ".join(f"{prop}={val}" for prop, val in pairs)
 
 
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -2,6 +2,7 @@ from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
+from typing import Dict, List, Optional, Tuple
 
 # LAYOUT_AXIS = {
 #     "NONE": None,
@@ -64,7 +65,101 @@ def post_process_symbol(fig_symbol, sketch_symbol):
     return sketch_symbol
 
 
+def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:
+    pairs = []
+    for part in symbol_name.split(","):
+        part = part.strip()
+        if "=" not in part:
+            continue
+        prop, _, val = part.partition("=")
+        pairs.append((prop.strip(), val.strip()))
+    return pairs
+
+
 def symbol_variant_name(parent, symbol):
-    property_values = [x.strip().split("=")[1] for x in symbol["name"].split(",")]
-    ordered_values = [parent["name"]] + property_values
+    pairs = parse_variant_values(symbol["name"])
+    ordered_values = [parent["name"]] + [val for _, val in pairs]
     return "/".join(ordered_values)
+
+
+def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
+    parent_guid = parent["guid"]
+    orders = parent.get("stateGroupPropertyValueOrders", [])
+
+    if orders:
+        return _variant_properties_from_orders(parent_guid, orders)
+
+    return _variant_properties_from_children(parent)
+
+
+def _variant_properties_from_orders(
+    parent_guid, orders: list
+) -> List[VariantProperty]:
+    properties = []
+    for order in orders:
+        prop_name = order["property"]
+        prop_id = utils.gen_object_id(
+            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
+        )
+        values = []
+        for val_name in order["values"]:
+            val_id = utils.gen_object_id(
+                parent_guid,
+                b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
+            )
+            values.append(VariantPropertyValue(do_objectID=val_id, name=val_name))
+        properties.append(VariantProperty(do_objectID=prop_id, name=prop_name, values=values))
+    return properties
+
+
+def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProperty]]:
+    from collections import OrderedDict
+
+    prop_values: OrderedDict[str, list] = OrderedDict()
+    for child in parent.get("children", []):
+        if child.get("type") != "SYMBOL":
+            continue
+        for prop_name, val_name in parse_variant_values(child["name"]):
+            if prop_name not in prop_values:
+                prop_values[prop_name] = []
+            if val_name not in prop_values[prop_name]:
+                prop_values[prop_name].append(val_name)
+
+    if not prop_values:
+        utils.log_conversion_warning("VAR001", parent)
+        return None
+
+    parent_guid = parent["guid"]
+    properties = []
+    for prop_name, val_names in prop_values.items():
+        prop_id = utils.gen_object_id(
+            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
+        )
+        values = []
+        for val_name in val_names:
+            val_id = utils.gen_object_id(
+                parent_guid,
+                b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
+            )
+            values.append(VariantPropertyValue(do_objectID=val_id, name=val_name))
+        properties.append(VariantProperty(do_objectID=prop_id, name=prop_name, values=values))
+    return properties
+
+
+def build_variant_specs(parent_guid, fig_symbol: dict) -> Optional[Dict[str, str]]:
+    pairs = parse_variant_values(fig_symbol["name"])
+    if not pairs:
+        utils.log_conversion_warning("VAR002", fig_symbol)
+        return None
+
+    specs = {}
+    for prop_name, val_name in pairs:
+        prop_id = utils.gen_object_id(
+            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
+        )
+        val_id = utils.gen_object_id(
+            parent_guid,
+            b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
+        )
+        specs[prop_id] = val_id
+    return specs

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -34,7 +34,7 @@ def convert(fig_symbol):
     try:
         parent = context.fig_node(fig_symbol["parent"]["guid"])
         if parent and parent.get("isStateGroup", False):
-            master.name = symbol_variant_name(parent, fig_symbol)
+            master.name = fig_symbol["name"]
             master.variantSpecs = build_variant_specs(parent["guid"], fig_symbol)
 
     except Exception as e:
@@ -74,14 +74,6 @@ def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:
         prop, _, val = part.partition("=")
         pairs.append((prop.strip(), val.strip()))
     return pairs
-
-
-def symbol_variant_name(_parent, symbol):
-    pairs = parse_variant_values(symbol["name"])
-    if not pairs:
-        return symbol["name"]
-
-    return ", ".join(f"{prop}={val}" for prop, val in pairs)
 
 
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -31,11 +31,11 @@ def convert(fig_symbol):
     # Keep the base ID as the symbol reference, create a new one for the container
     master.do_objectID = utils.gen_object_id(fig_symbol["guid"], b"symbol_master")
 
-    # Use better names for variants if possible
     try:
         parent = context.fig_node(fig_symbol["parent"]["guid"])
         if parent and parent.get("isStateGroup", False):
             master.name = symbol_variant_name(parent, fig_symbol)
+            master.variantSpecs = build_variant_specs(parent["guid"], fig_symbol)
 
     except Exception as e:
         print(e)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -56,6 +56,12 @@ def post_process_symbol(fig_symbol, sketch_symbol):
     if utils.has_auto_layout(fig_symbol):
         sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)
 
+    if context.component_set_for_symbol(fig_symbol["guid"]):
+        # The hidden component set frame is emitted to the Symbols page. Keep its
+        # variant symbol masters inside that frame so their variantSpecs match the
+        # frame's variantProperties.
+        return sketch_symbol
+
     if context.is_component_page_symbol(fig_symbol["guid"]):
         # Symbol lives on .fig's hidden components page — move it to the Symbols page
         context.add_symbol(sketch_symbol)

--- a/src/converter/symbol.py
+++ b/src/converter/symbol.py
@@ -2,7 +2,7 @@ from . import instance, group, base, prototype, layout
 from .context import context
 from converter import utils
 from sketchformat.layer_group import *
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Tuple
 
 # LAYOUT_AXIS = {
 #     "NONE": None,
@@ -35,7 +35,7 @@ def convert(fig_symbol):
         parent = context.fig_node(fig_symbol["parent"]["guid"])
         if parent and parent.get("isStateGroup", False):
             master.name = fig_symbol["name"]
-            master.variantSpecs = build_variant_specs(parent["guid"], fig_symbol)
+            master.variantSpecs = build_variant_specs(parent, fig_symbol)
 
     except Exception as e:
         print(e)
@@ -46,18 +46,18 @@ def convert(fig_symbol):
 def post_process_symbol(fig_symbol, sketch_symbol):
     """Finalize a converted symbol and decide where its master should live.
 
-    Symbols from Figma's hidden components page are moved to Sketch's Symbols page
-    and replaced at the original site with an instance. Symbols from visible Figma
+    Symbols from .fig format's hidden components page are moved to Sketch's Symbols page
+    and replaced at the original site with an instance. Symbols from visible .fig
     pages are returned unchanged so they stay in place. The hidden-page check is
-    based on the component symbol IDs collected when the conversion context is
+    based on the component symbol IDs collected when the conversion context iss
     initialized.
     """
-    # Figma stores its stack children in bottom up order, but Sketch uses top down
+    # .fig stores its stack children in bottom up order, but Sketch uses top down
     if utils.has_auto_layout(fig_symbol):
         sketch_symbol = layout.post_process_group_layout(fig_symbol, sketch_symbol)
 
     if context.is_component_page_symbol(fig_symbol["guid"]):
-        # Symbol lives on Figma's hidden components page — move it to the Symbols page
+        # Symbol lives on .fig's hidden components page — move it to the Symbols page
         context.add_symbol(sketch_symbol)
         return instance.master_instance(fig_symbol)
 
@@ -65,72 +65,25 @@ def post_process_symbol(fig_symbol, sketch_symbol):
     return sketch_symbol
 
 
-def parse_variant_values(symbol_name: str) -> List[Tuple[str, str]]:
-    pairs = []
-    for part in symbol_name.split(","):
-        part = part.strip()
-        if "=" not in part:
-            continue
-        prop, _, val = part.partition("=")
-        pairs.append((prop.strip(), val.strip()))
-    return pairs
-
-
 def build_variant_properties(parent: dict) -> Optional[List[VariantProperty]]:
-    parent_guid = parent["guid"]
-    orders = parent.get("stateGroupPropertyValueOrders", [])
+    """Build VariantProperty list from stateGroupPropertyValueOrders on the component set.
 
-    if orders:
-        return _variant_properties_from_orders(parent_guid, orders)
-
-    return _variant_properties_from_children(parent)
-
-
-def _variant_properties_from_orders(
-    parent_guid: Sequence[int], orders: list
-) -> List[VariantProperty]:
-    properties = []
-    for order in orders:
-        prop_name = order["property"]
-        prop_id = utils.gen_object_id(
-            parent_guid, b"variant_property:" + prop_name.encode("utf-8")
-        )
-        values = []
-        for val_name in order["values"]:
-            val_id = utils.gen_object_id(
-                parent_guid,
-                b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
-            )
-            values.append(VariantPropertyValue(do_objectID=val_id, name=val_name))
-        properties.append(VariantProperty(do_objectID=prop_id, name=prop_name, values=values))
-    return properties
-
-
-def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProperty]]:
-    from collections import OrderedDict
-
-    prop_values: OrderedDict[str, list] = OrderedDict()
-    for child in parent.get("children", []):
-        if child.get("type") != "SYMBOL":
-            continue
-        for prop_name, val_name in parse_variant_values(child["name"]):
-            if prop_name not in prop_values:
-                prop_values[prop_name] = []
-            if val_name not in prop_values[prop_name]:
-                prop_values[prop_name].append(val_name)
-
-    if not prop_values:
+    The order of properties and their values is preserved from .fig format ordering,
+    which controls how variants are presented in the Sketch inspector.
+    """
+    orderedPropertyValues = parent.get("stateGroupPropertyValueOrders", [])
+    if not orderedPropertyValues:
         utils.log_conversion_warning("VAR001", parent)
         return None
-
     parent_guid = parent["guid"]
     properties = []
-    for prop_name, val_names in prop_values.items():
+    for orderedPropertyValue in orderedPropertyValues:
+        prop_name = orderedPropertyValue["property"]
         prop_id = utils.gen_object_id(
             parent_guid, b"variant_property:" + prop_name.encode("utf-8")
         )
         values = []
-        for val_name in val_names:
+        for val_name in orderedPropertyValue["values"]:
             val_id = utils.gen_object_id(
                 parent_guid,
                 b"variant_value:" + prop_name.encode("utf-8") + b":" + val_name.encode("utf-8"),
@@ -140,9 +93,13 @@ def _variant_properties_from_children(parent: dict) -> Optional[List[VariantProp
     return properties
 
 
-def build_variant_specs(parent_guid: Sequence[int], fig_symbol: dict) -> Optional[Dict[str, str]]:
+def build_variant_specs(parent: dict, fig_symbol: dict) -> Optional[Dict[str, str]]:
     """Map VariantProperty objectID → VariantPropertyValue objectID for this symbol."""
-    pairs = parse_variant_values(fig_symbol["name"])
+    parent_guid = parent["guid"]
+    prop_specs = fig_symbol.get("variantPropSpecs", [])
+
+    pairs = _pairs_from_prop_specs(parent, prop_specs)
+
     if not pairs:
         utils.log_conversion_warning("VAR002", fig_symbol)
         return None
@@ -158,3 +115,19 @@ def build_variant_specs(parent_guid: Sequence[int], fig_symbol: dict) -> Optiona
         )
         specs[prop_id] = val_id
     return specs
+
+
+def _pairs_from_prop_specs(parent: dict, prop_specs: list) -> List[Tuple[str, str]]:
+    """Resolve variantPropSpecs entries to (property_name, value) pairs via componentPropDefs."""
+    prop_defs = {
+        tuple(d["id"]): d["name"]
+        for d in parent.get("componentPropDefs", [])
+        if d.get("type") == "VARIANT"
+    }
+
+    pairs = []
+    for spec in prop_specs:
+        prop_name = prop_defs.get(tuple(spec["propDefId"]))
+        if prop_name is not None:
+            pairs.append((prop_name, spec["value"]))
+    return pairs

--- a/src/converter/utils.py
+++ b/src/converter/utils.py
@@ -109,6 +109,8 @@ WARNING_MESSAGES = {
     "LAY001": "is an unsupported layer type, it will not be converted",
     "NOD001": "node could not be found",
     "STK001": "has a stack layout with last on top ordering and a child which ignores the layout. This layout will not be converted.",
+    "VAR001": "is a component set but has no parseable variant properties. Variant data will not be converted",
+    "VAR002": "is a variant but its name could not be parsed for variant values. Its variantSpecs will be empty",
 }
 
 

--- a/src/sketchformat/layer_group.py
+++ b/src/sketchformat/layer_group.py
@@ -2,7 +2,7 @@ from .layer_common import *
 from .common import WindingRule
 from .prototype import *
 from enum import IntEnum
-from typing import Any, Optional, List
+from typing import Any, Dict, Optional, List
 
 
 class LayoutAxis(IntEnum):
@@ -81,6 +81,21 @@ class InferredGroupLayout:
 
 
 @dataclass(kw_only=True)
+class VariantPropertyValue:
+    _class: str = field(default="variantPropertyValue")
+    do_objectID: str
+    name: str
+
+
+@dataclass(kw_only=True)
+class VariantProperty:
+    _class: str = field(default="variantProperty")
+    do_objectID: str
+    name: str
+    values: List[VariantPropertyValue] = field(default_factory=list)
+
+
+@dataclass(kw_only=True)
 class AbstractLayerGroup(AbstractStyledLayer):
     hasClickThrough: bool = False
     groupBehavior: int = 0
@@ -94,6 +109,7 @@ class AbstractLayerGroup(AbstractStyledLayer):
     bottomPadding: float = 0
     paddingSelection: PaddingSelection = PaddingSelection.UNIFORM
     layers: List[AbstractLayer] = field(default_factory=list)
+    variantProperties: Optional[List[VariantProperty]] = None
 
 
 @dataclass(kw_only=True)
@@ -150,6 +166,7 @@ class SymbolMaster(Frame):
     includeBackgroundColorInInstance: bool = True
     symbolID: str
     overrideProperties: List[OverrideProperty] = field(default_factory=list)
+    variantSpecs: Optional[Dict[str, str]] = None
 
 
 @dataclass(kw_only=True)

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -100,7 +100,10 @@ def test_variant_name():
         "children": [{**FIG_SYMBOL, "name": "Property 1=Potato, Property 2=Another"}],
         "parent": {"guid": (22, 22)},
     }
-    assert symbol.symbol_variant_name(variants, variants["children"][0]) == "Starch/Potato/Another"
+    assert (
+        symbol.symbol_variant_name(variants, variants["children"][0])
+        == "Property 1=Potato, Property 2=Another"
+    )
 
 
 # --- parse_variant_values ---
@@ -229,7 +232,7 @@ def test_variant_ids_match(no_prototyping, component_set_context):
 def test_variant_name_preserved(no_prototyping, component_set_context):
     master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    assert master.name == "Button/Small/Default"
+    assert master.name == "Size=Small, State=Default"
 
 
 def test_non_variant_symbol_unaffected(no_prototyping, empty_context):

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -1,5 +1,6 @@
 from .base import *
-from converter import tree, symbol
+from converter import tree, symbol, utils
+from sketchformat.layer_group import VariantProperty, VariantPropertyValue
 from sketchformat.layer_shape import Rectangle
 import pytest
 from converter.context import context
@@ -8,6 +9,38 @@ FIG_SYMBOL = {
     **FIG_BASE,
     "type": "SYMBOL",
     "children": [],
+}
+
+FIG_COMPONENT_SET = {
+    **FIG_BASE,
+    "type": "FRAME",
+    "name": "Button",
+    "guid": (10, 10),
+    "isStateGroup": True,
+    "resizeToFit": False,
+    "stateGroupPropertyValueOrders": [
+        {"property": "Size", "values": ["Small", "Large"]},
+        {"property": "State", "values": ["Default", "Hover"]},
+    ],
+    "children": [
+        {
+            **FIG_BASE,
+            "type": "SYMBOL",
+            "name": "Size=Small, State=Default",
+            "guid": (11, 11),
+            "children": [],
+            "parent": {"guid": (10, 10)},
+        },
+        {
+            **FIG_BASE,
+            "type": "SYMBOL",
+            "name": "Size=Large, State=Hover",
+            "guid": (12, 12),
+            "children": [],
+            "parent": {"guid": (10, 10)},
+        },
+    ],
+    "parent": {"guid": (1, 1)},
 }
 
 
@@ -68,3 +101,151 @@ def test_variant_name():
         "parent": {"guid": (22, 22)},
     }
     assert symbol.symbol_variant_name(variants, variants["children"][0]) == "Starch/Potato/Another"
+
+
+# --- parse_variant_values ---
+
+
+def test_parse_variant_values():
+    assert symbol.parse_variant_values("Size=Small, State=Default") == [
+        ("Size", "Small"),
+        ("State", "Default"),
+    ]
+
+
+def test_parse_variant_values_single():
+    assert symbol.parse_variant_values("Tinted=True") == [("Tinted", "True")]
+
+
+def test_parse_variant_values_malformed():
+    assert symbol.parse_variant_values("NoEquals") == []
+
+
+def test_parse_variant_values_empty_value():
+    assert symbol.parse_variant_values("A=1, B=, C=3") == [("A", "1"), ("B", ""), ("C", "3")]
+
+
+# --- build_variant_properties ---
+
+
+def test_build_variant_properties():
+    props = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    assert len(props) == 2
+    assert props[0].name == "Size"
+    assert [v.name for v in props[0].values] == ["Small", "Large"]
+    assert props[1].name == "State"
+    assert [v.name for v in props[1].values] == ["Default", "Hover"]
+
+
+def test_build_variant_properties_ids_are_deterministic():
+    props_a = symbol.build_variant_properties(FIG_COMPONENT_SET)
+    props_b = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    assert props_a[0].do_objectID == props_b[0].do_objectID
+    assert props_a[0].values[0].do_objectID == props_b[0].values[0].do_objectID
+
+
+def test_build_variant_properties_fallback(warnings):
+    parent = {
+        **FIG_BASE,
+        "type": "FRAME",
+        "name": "Fallback",
+        "guid": (20, 20),
+        "isStateGroup": True,
+        "children": [
+            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Red, Size=Big", "guid": (21, 21)},
+            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Blue, Size=Small", "guid": (22, 22)},
+        ],
+    }
+    props = symbol.build_variant_properties(parent)
+
+    assert len(props) == 2
+    assert props[0].name == "Color"
+    assert [v.name for v in props[0].values] == ["Red", "Blue"]
+    assert props[1].name == "Size"
+    assert [v.name for v in props[1].values] == ["Big", "Small"]
+
+
+def test_build_variant_properties_fallback_no_children(warnings):
+    parent = {
+        **FIG_BASE,
+        "type": "FRAME",
+        "name": "Empty",
+        "guid": (30, 30),
+        "isStateGroup": True,
+        "children": [],
+    }
+    assert symbol.build_variant_properties(parent) is None
+    warnings.assert_called_with("VAR001", parent)
+
+
+# --- Full pipeline: variant data on converted layers ---
+
+
+@pytest.fixture
+def component_set_context(monkeypatch):
+    page = {
+        **FIG_BASE,
+        "type": "CANVAS",
+        "name": "Page",
+        "guid": (1, 1),
+        "children": [FIG_COMPONENT_SET],
+        "parent": {"guid": (0, 0)},
+        "backgroundEnabled": False,
+        "backgrounds": [],
+    }
+    id_map = {}
+    _collect_ids(page, id_map)
+    context.init(None, id_map, "DISPLAY_P3")
+
+
+def _collect_ids(node, id_map):
+    id_map[tuple(node["guid"])] = node
+    for child in node.get("children", []):
+        _collect_ids(child, id_map)
+
+
+def test_variant_specs_on_symbol_master(no_prototyping, component_set_context):
+    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+
+    master = context.symbols_page.layers[0]
+    assert master.variantSpecs is not None
+    assert len(master.variantSpecs) == 2
+
+
+def test_variant_ids_match(no_prototyping, component_set_context):
+    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+
+    master = context.symbols_page.layers[0]
+    props = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    prop_ids = {p.do_objectID for p in props}
+    val_ids = {v.do_objectID for p in props for v in p.values}
+
+    for prop_id, val_id in master.variantSpecs.items():
+        assert prop_id in prop_ids
+        assert val_id in val_ids
+
+
+def test_variant_name_preserved(no_prototyping, component_set_context):
+    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+
+    master = context.symbols_page.layers[0]
+    assert master.name == "Button/Small/Default"
+
+
+def test_non_variant_symbol_unaffected(no_prototyping, empty_context):
+    tree.convert_node({**FIG_SYMBOL}, "")
+
+    master = context.symbols_page.layers[0]
+    assert master.variantSpecs is None
+
+
+def test_variant_properties_on_frame(no_prototyping, component_set_context):
+    sketch_frame = tree.convert_node(FIG_COMPONENT_SET, "CANVAS")
+
+    assert sketch_frame.variantProperties is not None
+    assert len(sketch_frame.variantProperties) == 2
+    assert sketch_frame.variantProperties[0].name == "Size"
+    assert sketch_frame.variantProperties[1].name == "State"

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -208,6 +208,51 @@ def test_variant_properties_on_frame(no_prototyping, component_set_context):
     assert sketch_frame.variantProperties[1].name == "State"
 
 
+def test_hidden_component_set_emits_variant_set(no_prototyping, empty_context):
+    component_set = {**FIG_COMPONENT_SET, "parent": {"guid": (2, 2)}}
+    components_page = {
+        **FIG_BASE,
+        "type": "CANVAS",
+        "name": "Internal Only Canvas",
+        "guid": (2, 2),
+        "internalOnly": True,
+        "children": [component_set],
+        "parent": {"guid": (0, 0)},
+    }
+    fig_instance = {
+        **FIG_BASE,
+        "type": "INSTANCE",
+        "name": "Button instance",
+        "guid": (20, 20),
+        "symbolData": {
+            "symbolID": FIG_COMPONENT_SET["children"][0]["guid"],
+            "symbolOverrides": [],
+        },
+        "derivedSymbolData": [],
+        "resizeToFit": True,
+    }
+    id_map = {}
+    _collect_ids(components_page, id_map)
+    context.init(components_page, id_map, "DISPLAY_P3")
+
+    sketch_instance = tree.convert_node(fig_instance, "FRAME")
+
+    assert sketch_instance._class == "symbolInstance"
+    assert len(context.symbols_page.layers) == 1
+
+    variant_set = context.symbols_page.layers[0]
+    assert variant_set._class == "group"
+    assert variant_set.name == "Button"
+    assert variant_set.groupBehavior == 3
+    assert variant_set.variantProperties is not None
+    assert len(variant_set.layers) == 2
+
+    variant_master = variant_set.layers[0]
+    assert variant_master._class == "symbolMaster"
+    assert variant_master.variantSpecs is not None
+    assert sketch_instance.symbolID == variant_master.symbolID
+
+
 def test_variant_specs_from_variantPropSpecs(no_prototyping, component_set_context):
     """variantSpecs are built from variantPropSpecs + componentPropDefs, not name parsing."""
     master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -245,7 +245,15 @@ def test_non_variant_symbol_unaffected(no_prototyping, empty_context):
 def test_variant_properties_on_frame(no_prototyping, component_set_context):
     sketch_frame = tree.convert_node(FIG_COMPONENT_SET, "CANVAS")
 
+    assert sketch_frame.groupBehavior == 3
     assert sketch_frame.variantProperties is not None
     assert len(sketch_frame.variantProperties) == 2
     assert sketch_frame.variantProperties[0].name == "Size"
     assert sketch_frame.variantProperties[1].name == "State"
+
+
+def test_non_variant_frame_keeps_default_group_behavior(no_prototyping, empty_context):
+    fig_frame = {**FIG_BASE, "type": "FRAME", "resizeToFit": False, "children": []}
+    sketch_frame = tree.convert_node(fig_frame, "CANVAS")
+
+    assert sketch_frame.groupBehavior == 1

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -86,7 +86,7 @@ def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
     ]
 
 
-def test_variant_name():
+def test_variant_name_uses_figma_name_as_is(no_prototyping, empty_context):
     variants = {
         **FIG_BASE,
         "type": "FRAME",
@@ -100,10 +100,11 @@ def test_variant_name():
         "children": [{**FIG_SYMBOL, "name": "Property 1=Potato, Property 2=Another"}],
         "parent": {"guid": (22, 22)},
     }
-    assert (
-        symbol.symbol_variant_name(variants, variants["children"][0])
-        == "Property 1=Potato, Property 2=Another"
-    )
+    context._node_by_id[(22, 22)] = variants
+
+    master = tree.convert_node(variants["children"][0], "FRAME")
+
+    assert master.name == "Property 1=Potato, Property 2=Another"
 
 
 # --- parse_variant_values ---

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -22,6 +22,10 @@ FIG_COMPONENT_SET = {
         {"property": "Size", "values": ["Small", "Large"]},
         {"property": "State", "values": ["Default", "Hover"]},
     ],
+    "componentPropDefs": [
+        {"id": (100, 1), "name": "Size", "type": "VARIANT"},
+        {"id": (100, 2), "name": "State", "type": "VARIANT"},
+    ],
     "children": [
         {
             **FIG_BASE,
@@ -30,6 +34,10 @@ FIG_COMPONENT_SET = {
             "guid": (11, 11),
             "children": [],
             "parent": {"guid": (10, 10)},
+            "variantPropSpecs": [
+                {"propDefId": (100, 1), "value": "Small"},
+                {"propDefId": (100, 2), "value": "Default"},
+            ],
         },
         {
             **FIG_BASE,
@@ -38,6 +46,10 @@ FIG_COMPONENT_SET = {
             "guid": (12, 12),
             "children": [],
             "parent": {"guid": (10, 10)},
+            "variantPropSpecs": [
+                {"propDefId": (100, 1), "value": "Large"},
+                {"propDefId": (100, 2), "value": "Hover"},
+            ],
         },
     ],
     "parent": {"guid": (1, 1)},
@@ -86,7 +98,7 @@ def test_inner_shadows_children_of_symbol(no_prototyping, empty_context):
     ]
 
 
-def test_variant_name_uses_figma_name_as_is(no_prototyping, empty_context):
+def test_variant_name_uses_fig_name_as_is(no_prototyping, empty_context):
     variants = {
         **FIG_BASE,
         "type": "FRAME",
@@ -105,28 +117,6 @@ def test_variant_name_uses_figma_name_as_is(no_prototyping, empty_context):
     master = tree.convert_node(variants["children"][0], "FRAME")
 
     assert master.name == "Property 1=Potato, Property 2=Another"
-
-
-# --- parse_variant_values ---
-
-
-def test_parse_variant_values():
-    assert symbol.parse_variant_values("Size=Small, State=Default") == [
-        ("Size", "Small"),
-        ("State", "Default"),
-    ]
-
-
-def test_parse_variant_values_single():
-    assert symbol.parse_variant_values("Tinted=True") == [("Tinted", "True")]
-
-
-def test_parse_variant_values_malformed():
-    assert symbol.parse_variant_values("NoEquals") == []
-
-
-def test_parse_variant_values_empty_value():
-    assert symbol.parse_variant_values("A=1, B=, C=3") == [("A", "1"), ("B", ""), ("C", "3")]
 
 
 # --- build_variant_properties ---
@@ -148,40 +138,6 @@ def test_build_variant_properties_ids_are_deterministic():
 
     assert props_a[0].do_objectID == props_b[0].do_objectID
     assert props_a[0].values[0].do_objectID == props_b[0].values[0].do_objectID
-
-
-def test_build_variant_properties_fallback(warnings):
-    parent = {
-        **FIG_BASE,
-        "type": "FRAME",
-        "name": "Fallback",
-        "guid": (20, 20),
-        "isStateGroup": True,
-        "children": [
-            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Red, Size=Big", "guid": (21, 21)},
-            {**FIG_BASE, "type": "SYMBOL", "name": "Color=Blue, Size=Small", "guid": (22, 22)},
-        ],
-    }
-    props = symbol.build_variant_properties(parent)
-
-    assert len(props) == 2
-    assert props[0].name == "Color"
-    assert [v.name for v in props[0].values] == ["Red", "Blue"]
-    assert props[1].name == "Size"
-    assert [v.name for v in props[1].values] == ["Big", "Small"]
-
-
-def test_build_variant_properties_fallback_no_children(warnings):
-    parent = {
-        **FIG_BASE,
-        "type": "FRAME",
-        "name": "Empty",
-        "guid": (30, 30),
-        "isStateGroup": True,
-        "children": [],
-    }
-    assert symbol.build_variant_properties(parent) is None
-    warnings.assert_called_with("VAR001", parent)
 
 
 # --- Full pipeline: variant data on converted layers ---
@@ -250,6 +206,23 @@ def test_variant_properties_on_frame(no_prototyping, component_set_context):
     assert len(sketch_frame.variantProperties) == 2
     assert sketch_frame.variantProperties[0].name == "Size"
     assert sketch_frame.variantProperties[1].name == "State"
+
+
+def test_variant_specs_from_variantPropSpecs(no_prototyping, component_set_context):
+    """variantSpecs are built from variantPropSpecs + componentPropDefs, not name parsing."""
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    props = symbol.build_variant_properties(FIG_COMPONENT_SET)
+
+    prop_by_name = {p.name: p for p in props}
+    val_by_name = {(p.name, v.name): v for p in props for v in p.values}
+
+    size_prop_id = prop_by_name["Size"].do_objectID
+    small_val_id = val_by_name[("Size", "Small")].do_objectID
+    state_prop_id = prop_by_name["State"].do_objectID
+    default_val_id = val_by_name[("State", "Default")].do_objectID
+
+    assert master.variantSpecs[size_prop_id] == small_val_id
+    assert master.variantSpecs[state_prop_id] == default_val_id
 
 
 def test_non_variant_frame_keeps_default_group_behavior(no_prototyping, empty_context):

--- a/tests/converter/test_symbol.py
+++ b/tests/converter/test_symbol.py
@@ -207,17 +207,15 @@ def _collect_ids(node, id_map):
 
 
 def test_variant_specs_on_symbol_master(no_prototyping, component_set_context):
-    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    master = context.symbols_page.layers[0]
     assert master.variantSpecs is not None
     assert len(master.variantSpecs) == 2
 
 
 def test_variant_ids_match(no_prototyping, component_set_context):
-    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    master = context.symbols_page.layers[0]
     props = symbol.build_variant_properties(FIG_COMPONENT_SET)
 
     prop_ids = {p.do_objectID for p in props}
@@ -229,16 +227,14 @@ def test_variant_ids_match(no_prototyping, component_set_context):
 
 
 def test_variant_name_preserved(no_prototyping, component_set_context):
-    tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
+    master = tree.convert_node(FIG_COMPONENT_SET["children"][0], "FRAME")
 
-    master = context.symbols_page.layers[0]
     assert master.name == "Button/Small/Default"
 
 
 def test_non_variant_symbol_unaffected(no_prototyping, empty_context):
-    tree.convert_node({**FIG_SYMBOL}, "")
+    master = tree.convert_node({**FIG_SYMBOL}, "")
 
-    master = context.symbols_page.layers[0]
     assert master.variantSpecs is None
 
 


### PR DESCRIPTION
## Summary

- Add Sketch data types for variant properties, variant property values, and symbol variant specs.
- Parse component-set property/value metadata, using explicit value order data when available and falling back to child symbol names.
- Attach `variantProperties` to component-set frames and `variantSpecs` to variant symbol masters.
- Set component-set frames to Sketch's variant-set group behavior and add focused converter coverage.
- Import hidden component-page variant sets when visible instances reference their variants.