### PR TITLE
🔧 Upgrade mypy for Python 3.14

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+files = src/fig2sketch.py
 ignore_missing_imports = True
 disallow_untyped_calls = True
 disallow_incomplete_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ enabled = true
 
 [project.optional-dependencies]
 fast = ["fig-kiwi==0.1.2"]
-dev = ["black==26.3.1", "mypy==0.991", "pytest==9.0.3", "fig-kiwi==0.1.2"]
+dev = ["black==26.3.1", "mypy==1.20.2", "pytest==9.0.3", "fig-kiwi==0.1.2"]
 
 [tool.black]
 line-length = 99


### PR DESCRIPTION
## Summary
- Upgrade the dev mypy pin from 0.991 to 1.20.2 so the Python 3.14 virtualenv can run mypy without the obsolete typed_ast dependency path.
- Configure bare mypy runs to check src/fig2sketch.py, matching the existing GitHub Actions mypy target.