### PR TITLE
🤪 Fix nested vector transform duplication

### DIFF
--- a/src/converter/shape_path.py
+++ b/src/converter/shape_path.py
@@ -48,8 +48,7 @@ def convert(fig_vector: dict) -> Union[Group, ShapeGroup, ShapePath]:
         # Ignore positioning for children. TODO: We should probably be building these shapePaths by
         # hand, instead of relying on the generic convert_shape_path function
         for s in regions:
-            s.frame.x = 0
-            s.frame.y = 0
+            reset_child_positioning(s)
 
         obj = Group(**base.base_styled(fig_vector), layers=regions)  # type: ignore[arg-type]
         obj.style.fills = []
@@ -72,8 +71,7 @@ def convert_region(
     if len(loops) > 1:
         # Ignore positioning for children.
         for s in loops:
-            s.frame.x = 0
-            s.frame.y = 0
+            reset_child_positioning(s)
 
         obj = ShapeGroup(
             **base.base_styled({**fig_vector, **region["style"]}),
@@ -89,6 +87,14 @@ def convert_region(
         return obj
     else:
         return loops[0]
+
+
+def reset_child_positioning(layer: Union[ShapeGroup, ShapePath]) -> None:
+    layer.frame.x = 0
+    layer.frame.y = 0
+    layer.rotation = 0
+    layer.isFlippedHorizontal = False
+    layer.isFlippedVertical = False
 
 
 def maybe_convert_cropped_image_fill(fig_vector: dict, style: dict) -> None:

--- a/tests/converter/test_shape_path.py
+++ b/tests/converter/test_shape_path.py
@@ -24,6 +24,62 @@ FIG_VECTOR = {
 }
 
 
+def rotated_vector_with_regions(regions):
+    return {
+        **FIG_VECTOR,
+        "transform": Matrix([[0.7071, -0.7071, 0], [0.7071, 0.7071, 0]]),
+        "vectorNetwork": {
+            "regions": regions,
+            "segments": [
+                {
+                    "start": 0,
+                    "end": 1,
+                    "tangentStart": {"x": 0, "y": 0},
+                    "tangentEnd": {"x": 0, "y": 0},
+                },
+                {
+                    "start": 1,
+                    "end": 2,
+                    "tangentStart": {"x": 0, "y": 0},
+                    "tangentEnd": {"x": 0, "y": 0},
+                },
+                {
+                    "start": 2,
+                    "end": 0,
+                    "tangentStart": {"x": 0, "y": 0},
+                    "tangentEnd": {"x": 0, "y": 0},
+                },
+                {
+                    "start": 3,
+                    "end": 4,
+                    "tangentStart": {"x": 0, "y": 0},
+                    "tangentEnd": {"x": 0, "y": 0},
+                },
+                {
+                    "start": 4,
+                    "end": 5,
+                    "tangentStart": {"x": 0, "y": 0},
+                    "tangentEnd": {"x": 0, "y": 0},
+                },
+                {
+                    "start": 5,
+                    "end": 3,
+                    "tangentStart": {"x": 0, "y": 0},
+                    "tangentEnd": {"x": 0, "y": 0},
+                },
+            ],
+            "vertices": [
+                {"x": 0, "y": 0},
+                {"x": 10, "y": 0},
+                {"x": 0, "y": 10},
+                {"x": 20, "y": 20},
+                {"x": 30, "y": 20},
+                {"x": 20, "y": 30},
+            ],
+        },
+    }
+
+
 class TestGeometry:
     def test_winding_rule_odd(self):
         fig = {
@@ -198,6 +254,51 @@ def test_mixed_corner_radii_are_reflected_in_style_corners():
     assert sp.style.corners.style == CornerStyle.ROUNDED
     assert sp.style.corners.smoothing is None
     assert sp.pointRadiusBehaviour == PointRadiusBehaviour.V1
+
+
+def test_generated_region_layers_do_not_duplicate_vector_rotation():
+    fig = rotated_vector_with_regions(
+        [
+            {
+                "windingRule": "NONZERO",
+                "loops": [[0, 1, 2]],
+                "style": {},
+            },
+            {
+                "windingRule": "NONZERO",
+                "loops": [[3, 4, 5]],
+                "style": {},
+            },
+        ]
+    )
+
+    sketch = shape_path.convert(fig)
+
+    assert isinstance(sketch, Group)
+    assert sketch.rotation == pytest.approx(-45)
+    assert [layer.rotation for layer in sketch.layers] == [0, 0]
+    assert [layer.frame.x for layer in sketch.layers] == [0, 0]
+    assert [layer.frame.y for layer in sketch.layers] == [0, 0]
+
+
+def test_generated_loop_layers_do_not_duplicate_vector_rotation():
+    fig = rotated_vector_with_regions(
+        [
+            {
+                "windingRule": "ODD",
+                "loops": [[0, 1, 2], [3, 4, 5]],
+                "style": {},
+            }
+        ]
+    )
+
+    sketch = shape_path.convert(fig)
+
+    assert isinstance(sketch, ShapeGroup)
+    assert sketch.rotation == pytest.approx(-45)
+    assert [layer.rotation for layer in sketch.layers] == [0, 0]
+    assert [layer.frame.x for layer in sketch.layers] == [0, 0]
+    assert [layer.frame.y for layer in sketch.layers] == [0, 0]
 
 
 def test_complex_vector():


### PR DESCRIPTION
Generated ShapePath and ShapeGroup children inherit positioning from the source vector while being wrapped in a parent layer that also carries that positioning. When the source vector is rotated, this can apply the same transform more than once and misplace nested elements.

Reset generated child layers back to local coordinates, including rotation and flips, after moving vector positioning to the wrapper layer. Add regression coverage for rotated vectors split into generated region and loop layers.

Part of #137 