### PR TITLE
📐 Scale resized symbol instances

### DIFF
--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -35,12 +35,25 @@ def convert(fig_instance):
     obj = SymbolInstance(
         **base.base_styled(fig_instance),
         symbolID=utils.gen_object_id(fig_master["guid"]),
+        scale=instance_scale(fig_instance, fig_master),
         overrideValues=sketch_overrides,
     )
     # Replace style
     obj.style = Style(do_objectID=utils.gen_object_id(fig_instance["guid"], b"style"))
 
     return obj
+
+
+def instance_scale(fig_instance: dict, fig_master: dict) -> float:
+    scale_x = utils.safe_div(fig_instance["size"]["x"], fig_master["size"]["x"])
+    scale_y = utils.safe_div(fig_instance["size"]["y"], fig_master["size"]["y"])
+
+    if not scale_x:
+        return scale_y or 1
+    if not scale_y:
+        return scale_x
+
+    return scale_x
 
 
 def post_process(fig_instance, sketch_instance):

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -76,7 +76,19 @@ class TestOverrides:
 
         assert isinstance(i, SymbolInstance)
         assert i.symbolID == symbol.symbolID
+        assert i.scale == 1
         assert i.overrideValues == []
+
+    def test_scaled_instance(self):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["size"] = {"x": 50, "y": 50}
+
+        i = tree.convert_node(fig, "")
+
+        assert isinstance(i, SymbolInstance)
+        assert i.frame.width == 50
+        assert i.frame.height == 50
+        assert i.scale == 0.5
 
     def test_text_override(self):
         fig = copy.deepcopy(FIG_INSTANCE)


### PR DESCRIPTION
Set the Sketch symbol instance scale from the instance size relative to the master size, so resized Figma instances keep their contents scaled inside the resized frame instead of rendering master contents at full size.

Part of #137