### PR TITLE
Support additional symbol instance overrides

### DIFF
--- a/src/converter/context.py
+++ b/src/converter/context.py
@@ -47,6 +47,9 @@ class Context:
         )
         self._component_nodes: Set[Sequence[int]] = set(find_node_ids(components_page))
         self._converted_component_sets: Set[Sequence[int]] = set()
+        self._node_by_key = {
+            node["key"]: node for node in id_map.values() if isinstance(node.get("key"), str)
+        }
 
         # Where to position symbols of the specified width
         # width -> (x, y)
@@ -80,6 +83,12 @@ class Context:
     def fig_node(self, fid: Sequence[int]) -> dict:
         if fid in self._node_by_id:
             return self._node_by_id[fid]
+        else:
+            raise Fig2SketchWarning("NOD001")
+
+    def fig_node_by_key(self, key: str) -> dict:
+        if key in self._node_by_key:
+            return self._node_by_key[key]
         else:
             raise Fig2SketchWarning("NOD001")
 

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -216,6 +216,10 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             sk, us = convert_style_ref_override(sketch_path_str, value, "border")
             sketch_overrides += sk
             unsupported_overrides += [f"styleIdForStroke.{p}" for p in us]
+        elif prop == "effects":
+            sk, us = convert_effect_overrides(sketch_path_str, value)
+            sketch_overrides += sk
+            unsupported_overrides += [f"effects.{p}" for p in us]
         elif prop in ["size", "pluginData", "name", "exportSettings", "targetAspectRatio"]:
             # Size is handled by applying derivedSymbolData
             # The rest are surely not worth detaching for
@@ -239,6 +243,36 @@ def sketch_override_object_id(fig_node: dict) -> str:
         return utils.gen_object_id(fig_node["guid"], b"region0loop0")
 
     return utils.gen_object_id(fig_node["guid"], b"region0")
+
+
+def convert_effect_overrides(
+    sketch_path_str: str, effects: list
+) -> Tuple[List[OverrideValue], List[str]]:
+    sketch_overrides = []
+    unsupported_overrides = []
+    effect_indexes = {"shadow": 0, "innershadow": 0}
+
+    for effect in effects:
+        if effect["type"] == "DROP_SHADOW":
+            part = "shadow"
+        elif effect["type"] == "INNER_SHADOW":
+            part = "innershadow"
+        else:
+            unsupported_overrides.append(effect["type"])
+            continue
+
+        part_path = f"{part}-{effect_indexes[part]}"
+        effect_indexes[part] += 1
+
+        if "color" in effect:
+            sketch_overrides.append(
+                OverrideValue(
+                    overrideName=f"{sketch_path_str}_color:{part_path}",
+                    value=style_converter.convert_color(effect["color"]),
+                )
+            )
+
+    return sketch_overrides, unsupported_overrides
 
 
 def convert_style_ref_override(

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -244,9 +244,13 @@ def sketch_override_object_id(fig_node: dict) -> str:
 def convert_style_ref_override(
     sketch_path_str: str, style_ref: dict, sketch_part: str
 ) -> Tuple[List[OverrideValue], List[str]]:
+    asset_ref = style_ref.get("assetRef")
+    if asset_ref is None:
+        return [], []
+
     try:
-        fig_style = context.fig_node_by_key(style_ref["assetRef"]["key"])
-    except Fig2SketchWarning:
+        fig_style = context.fig_node_by_key(asset_ref["key"])
+    except (Fig2SketchWarning, KeyError):
         return [], ["assetRef"]
 
     if "fillPaints" not in fig_style:

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -1,5 +1,5 @@
 import copy, logging
-from . import base, group
+from . import base, group, style as style_converter
 from .context import context
 from .config import config
 from converter import utils
@@ -16,6 +16,7 @@ def convert(fig_instance):
         return group.convert(fig_instance)
 
     all_overrides = get_all_overrides(fig_instance)
+    all_overrides = apply_root_overrides_to_instance(fig_instance, all_overrides)
     sketch_overrides, unsupported = convert_overrides(all_overrides, fig_instance)
     if unsupported:
         if config.can_detach:
@@ -40,6 +41,7 @@ def convert(fig_instance):
     )
     # Replace style
     obj.style = Style(do_objectID=utils.gen_object_id(fig_instance["guid"], b"style"))
+    obj.style.contextSettings.opacity = fig_instance.get("opacity", 1)
 
     return obj
 
@@ -87,6 +89,31 @@ def convert_overrides(all_overrides, fig_instance):
         unsupported_overrides += us
 
     return sketch_overrides, unsupported_overrides
+
+
+def apply_root_overrides_to_instance(fig_instance: dict, all_overrides: list) -> list:
+    fig_master = context.find_symbol(fig_instance["symbolData"]["symbolID"])
+    root_guid = fig_master.get("overrideKey", fig_master["guid"])
+    remaining_overrides = []
+
+    for override in all_overrides:
+        if override["guidPath"]["guids"] != [root_guid]:
+            remaining_overrides.append(override)
+            continue
+
+        remaining_root_override = {"guidPath": override["guidPath"]}
+        for prop, value in override.items():
+            if prop == "guidPath":
+                continue
+            if prop == "opacity":
+                fig_instance["opacity"] = value
+            else:
+                remaining_root_override[prop] = value
+
+        if len(remaining_root_override) > 1:
+            remaining_overrides.append(remaining_root_override)
+
+    return remaining_overrides
 
 
 def get_all_overrides(fig_instance):
@@ -173,6 +200,14 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
                     value=utils.gen_object_id(value),
                 )
             )
+        elif prop == "fillPaints":
+            sk, us = convert_style_part_overrides(sketch_path_str, value, "fill")
+            sketch_overrides += sk
+            unsupported_overrides += [f"fillPaints.{p}" for p in us]
+        elif prop == "strokePaints":
+            sk, us = convert_style_part_overrides(sketch_path_str, value, "border")
+            sketch_overrides += sk
+            unsupported_overrides += [f"strokePaints.{p}" for p in us]
         elif prop in ["size", "pluginData", "name", "exportSettings"]:
             # Size is handled by applying derivedSymbolData
             # The rest are surely not worth detaching for
@@ -182,6 +217,59 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             unsupported_overrides.append(prop)
 
     return sketch_overrides, unsupported_overrides
+
+
+def convert_style_part_overrides(
+    sketch_path_str: str, paints: list, sketch_part: str
+) -> Tuple[List[OverrideValue], List[str]]:
+    sketch_overrides = []
+    unsupported_overrides = []
+
+    for index, paint in enumerate(paints):
+        part_path = f"{sketch_part}-{index}"
+
+        if "color" in paint:
+            if paint.get("type") == "SOLID":
+                sketch_overrides.append(
+                    OverrideValue(
+                        overrideName=f"{sketch_path_str}_color:{part_path}",
+                        value=style_converter.convert_color(paint["color"]),
+                    )
+                )
+            else:
+                unsupported_overrides.append("color")
+
+        if "blendMode" in paint:
+            sketch_overrides.append(
+                OverrideValue(
+                    overrideName=f"{sketch_path_str}_blendMode:{part_path}",
+                    value=style_converter.BLEND_MODE[paint.get("blendMode", "NORMAL")],
+                )
+            )
+
+        if "opacity" in paint:
+            sketch_overrides.append(
+                OverrideValue(
+                    overrideName=f"{sketch_path_str}_opacity:{part_path}",
+                    value=paint["opacity"],
+                )
+            )
+
+        unsupported_overrides += unsupported_paint_override_props(paint)
+
+    return sketch_overrides, unsupported_overrides
+
+
+def unsupported_paint_override_props(paint: dict) -> List[str]:
+    ignored_props = {"blendMode", "color", "opacity", "type", "visible"}
+    if paint.get("type") == "SOLID":
+        return [prop for prop in paint if prop not in ignored_props]
+
+    return [
+        prop
+        for prop in paint
+        if prop not in ignored_props and prop not in ["image", "imageScaleMode", "scale"]
+    ]
 
 
 def find_symbol_master(root_symbol, guid_path, overrides):

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -208,7 +208,7 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             sk, us = convert_style_part_overrides(sketch_path_str, value, "border")
             sketch_overrides += sk
             unsupported_overrides += [f"strokePaints.{p}" for p in us]
-        elif prop in ["size", "pluginData", "name", "exportSettings"]:
+        elif prop in ["size", "pluginData", "name", "exportSettings", "targetAspectRatio"]:
             # Size is handled by applying derivedSymbolData
             # The rest are surely not worth detaching for
             pass

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -8,6 +8,13 @@ from sketchformat.style import Style
 from typing import List, Tuple
 from .errors import Fig2SketchNodeChanged, Fig2SketchWarning
 
+GRADIENT_PAINT_TYPES = {
+    "GRADIENT_LINEAR",
+    "GRADIENT_RADIAL",
+    "GRADIENT_ANGULAR",
+    "GRADIENT_DIAMOND",
+}
+
 
 def convert(fig_instance):
     if utils.is_invalid_ref(fig_instance["symbolData"]["symbolID"]):
@@ -200,25 +207,37 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             )
         elif prop == "fillPaints":
             sk, us = convert_style_part_overrides(
-                sketch_path_str, value, "fill", master_paints(fig_nodes[-1], "fill")
+                sketch_path_str,
+                value,
+                "fill",
+                fig_nodes[-1],
             )
             sketch_overrides += sk
             unsupported_overrides += [f"fillPaints.{p}" for p in us]
         elif prop == "strokePaints":
             sk, us = convert_style_part_overrides(
-                sketch_path_str, value, "border", master_paints(fig_nodes[-1], "border")
+                sketch_path_str,
+                value,
+                "border",
+                fig_nodes[-1],
             )
             sketch_overrides += sk
             unsupported_overrides += [f"strokePaints.{p}" for p in us]
         elif prop == "styleIdForFill":
             sk, us = convert_style_ref_override(
-                sketch_path_str, value, "fill", master_paints(fig_nodes[-1], "fill")
+                sketch_path_str,
+                value,
+                "fill",
+                fig_nodes[-1],
             )
             sketch_overrides += sk
             unsupported_overrides += [f"styleIdForFill.{p}" for p in us]
         elif prop == "styleIdForStroke":
             sk, us = convert_style_ref_override(
-                sketch_path_str, value, "border", master_paints(fig_nodes[-1], "border")
+                sketch_path_str,
+                value,
+                "border",
+                fig_nodes[-1],
             )
             sketch_overrides += sk
             unsupported_overrides += [f"styleIdForStroke.{p}" for p in us]
@@ -282,7 +301,10 @@ def convert_effect_overrides(
 
 
 def convert_style_ref_override(
-    sketch_path_str: str, style_ref: dict, sketch_part: str, master_part_paints: list
+    sketch_path_str: str,
+    style_ref: dict,
+    sketch_part: str,
+    master_node: dict,
 ) -> Tuple[List[OverrideValue], List[str]]:
     asset_ref = style_ref.get("assetRef")
     if asset_ref is None:
@@ -297,7 +319,10 @@ def convert_style_ref_override(
         return [], ["fillPaints"]
 
     return convert_style_part_overrides(
-        sketch_path_str, fig_style["fillPaints"], sketch_part, master_part_paints
+        sketch_path_str,
+        fig_style["fillPaints"],
+        sketch_part,
+        master_node,
     )
 
 
@@ -314,10 +339,14 @@ def master_paints(fig_node: dict, sketch_part: str) -> list:
 
 
 def convert_style_part_overrides(
-    sketch_path_str: str, paints: list, sketch_part: str, master_part_paints: list
+    sketch_path_str: str,
+    paints: list,
+    sketch_part: str,
+    master_node: dict,
 ) -> Tuple[List[OverrideValue], List[str]]:
     sketch_overrides = []
     unsupported_overrides = []
+    master_part_paints = master_paints(master_node, sketch_part)
 
     for index, paint in enumerate(paints):
         part_path = f"{sketch_part}-{index}"
@@ -340,6 +369,23 @@ def convert_style_part_overrides(
                     )
             else:
                 unsupported_overrides.append("color")
+
+        if paint.get("type") in GRADIENT_PAINT_TYPES and "stops" in paint and "transform" in paint:
+            gradient = style_converter.convert_gradient(master_node, paint)
+            master_gradient = (
+                style_converter.convert_gradient(master_node, master_paint)
+                if master_paint.get("type") in GRADIENT_PAINT_TYPES
+                and "stops" in master_paint
+                and "transform" in master_paint
+                else None
+            )
+            if gradient != master_gradient:
+                sketch_overrides.append(
+                    OverrideValue(
+                        overrideName=f"{sketch_path_str}_color:{part_path}",
+                        value=gradient,
+                    )
+                )
 
         blend_mode = style_converter.BLEND_MODE[paint.get("blendMode", "NORMAL")]
         master_blend_mode = style_converter.BLEND_MODE[master_paint.get("blendMode", "NORMAL")]
@@ -368,6 +414,16 @@ def unsupported_paint_override_props(paint: dict) -> List[str]:
     ignored_props = {"blendMode", "color", "opacity", "type", "visible"}
     if paint.get("type") == "SOLID":
         return [prop for prop in paint if prop not in ignored_props]
+
+    if paint.get("type") in GRADIENT_PAINT_TYPES:
+        gradient_props = {
+            "interpolationColorSpace",
+            "interpolationHueMethod",
+            "stops",
+            "stopsVar",
+            "transform",
+        }
+        return [prop for prop in paint if prop not in ignored_props and prop not in gradient_props]
 
     return [
         prop

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -208,8 +208,8 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
         elif prop == "fillPaints":
             sk, us = convert_style_part_overrides(
                 sketch_path_str,
-                value,
                 "fill",
+                value,
                 fig_nodes[-1],
             )
             sketch_overrides += sk
@@ -217,8 +217,8 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
         elif prop == "strokePaints":
             sk, us = convert_style_part_overrides(
                 sketch_path_str,
-                value,
                 "border",
+                value,
                 fig_nodes[-1],
             )
             sketch_overrides += sk
@@ -226,8 +226,8 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
         elif prop == "styleIdForFill":
             sk, us = convert_style_ref_override(
                 sketch_path_str,
-                value,
                 "fill",
+                value,
                 fig_nodes[-1],
             )
             sketch_overrides += sk
@@ -235,8 +235,8 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
         elif prop == "styleIdForStroke":
             sk, us = convert_style_ref_override(
                 sketch_path_str,
-                value,
                 "border",
+                value,
                 fig_nodes[-1],
             )
             sketch_overrides += sk
@@ -302,8 +302,8 @@ def convert_effect_overrides(
 
 def convert_style_ref_override(
     sketch_path_str: str,
-    style_ref: dict,
     sketch_part: str,
+    style_ref: dict,
     master_node: dict,
 ) -> Tuple[List[OverrideValue], List[str]]:
     asset_ref = style_ref.get("assetRef")
@@ -320,8 +320,8 @@ def convert_style_ref_override(
 
     return convert_style_part_overrides(
         sketch_path_str,
-        fig_style["fillPaints"],
         sketch_part,
+        fig_style["fillPaints"],
         master_node,
     )
 
@@ -340,8 +340,8 @@ def master_paints(fig_node: dict, sketch_part: str) -> list:
 
 def convert_style_part_overrides(
     sketch_path_str: str,
-    paints: list,
     sketch_part: str,
+    paints: list,
     master_node: dict,
 ) -> Tuple[List[OverrideValue], List[str]]:
     sketch_overrides = []

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -1,5 +1,5 @@
 import copy, logging
-from . import base, group, style as style_converter
+from . import base, group, shape_path as shape_path_converter, style as style_converter
 from .context import context
 from .config import config
 from converter import utils
@@ -169,7 +169,7 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
     try:
         # Convert uuids in the path from top symbol to child instance
         sketch_path = [
-            utils.gen_object_id(context.fig_node(guid)["guid"])
+            sketch_override_object_id(context.fig_node(guid))
             for guid in override["guidPath"]["guids"]
         ]
         sketch_path_str = "/".join(sketch_path)
@@ -225,6 +225,20 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             unsupported_overrides.append(prop)
 
     return sketch_overrides, unsupported_overrides
+
+
+def sketch_override_object_id(fig_node: dict) -> str:
+    if fig_node["type"] != "VECTOR" or "vectorNetwork" not in fig_node:
+        return utils.gen_object_id(fig_node["guid"])
+
+    regions = shape_path_converter.get_all_segments(fig_node["vectorNetwork"])
+    if len(regions) != 1:
+        return utils.gen_object_id(fig_node["guid"])
+
+    if len(regions[0]["loops"]) == 1:
+        return utils.gen_object_id(fig_node["guid"], b"region0loop0")
+
+    return utils.gen_object_id(fig_node["guid"], b"region0")
 
 
 def convert_style_ref_override(

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -167,11 +167,9 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
     unsupported_overrides = []
 
     try:
+        fig_nodes = [context.fig_node(guid) for guid in override["guidPath"]["guids"]]
         # Convert uuids in the path from top symbol to child instance
-        sketch_path = [
-            sketch_override_object_id(context.fig_node(guid))
-            for guid in override["guidPath"]["guids"]
-        ]
+        sketch_path = [sketch_override_object_id(fig_node) for fig_node in fig_nodes]
         sketch_path_str = "/".join(sketch_path)
     except KeyError as e:
         # Cannot find where to apply override
@@ -201,19 +199,27 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
                 )
             )
         elif prop == "fillPaints":
-            sk, us = convert_style_part_overrides(sketch_path_str, value, "fill")
+            sk, us = convert_style_part_overrides(
+                sketch_path_str, value, "fill", master_paints(fig_nodes[-1], "fill")
+            )
             sketch_overrides += sk
             unsupported_overrides += [f"fillPaints.{p}" for p in us]
         elif prop == "strokePaints":
-            sk, us = convert_style_part_overrides(sketch_path_str, value, "border")
+            sk, us = convert_style_part_overrides(
+                sketch_path_str, value, "border", master_paints(fig_nodes[-1], "border")
+            )
             sketch_overrides += sk
             unsupported_overrides += [f"strokePaints.{p}" for p in us]
         elif prop == "styleIdForFill":
-            sk, us = convert_style_ref_override(sketch_path_str, value, "fill")
+            sk, us = convert_style_ref_override(
+                sketch_path_str, value, "fill", master_paints(fig_nodes[-1], "fill")
+            )
             sketch_overrides += sk
             unsupported_overrides += [f"styleIdForFill.{p}" for p in us]
         elif prop == "styleIdForStroke":
-            sk, us = convert_style_ref_override(sketch_path_str, value, "border")
+            sk, us = convert_style_ref_override(
+                sketch_path_str, value, "border", master_paints(fig_nodes[-1], "border")
+            )
             sketch_overrides += sk
             unsupported_overrides += [f"styleIdForStroke.{p}" for p in us]
         elif prop == "effects":
@@ -276,7 +282,7 @@ def convert_effect_overrides(
 
 
 def convert_style_ref_override(
-    sketch_path_str: str, style_ref: dict, sketch_part: str
+    sketch_path_str: str, style_ref: dict, sketch_part: str, master_part_paints: list
 ) -> Tuple[List[OverrideValue], List[str]]:
     asset_ref = style_ref.get("assetRef")
     if asset_ref is None:
@@ -290,38 +296,62 @@ def convert_style_ref_override(
     if "fillPaints" not in fig_style:
         return [], ["fillPaints"]
 
-    return convert_style_part_overrides(sketch_path_str, fig_style["fillPaints"], sketch_part)
+    return convert_style_part_overrides(
+        sketch_path_str, fig_style["fillPaints"], sketch_part, master_part_paints
+    )
+
+
+def master_paints(fig_node: dict, sketch_part: str) -> list:
+    if sketch_part == "border":
+        return fig_node.get("strokePaints", [])
+
+    if fig_node["type"] == "VECTOR" and "vectorNetwork" in fig_node:
+        regions = shape_path_converter.get_all_segments(fig_node["vectorNetwork"])
+        if len(regions) == 1:
+            return regions[0]["style"].get("fillPaints", fig_node.get("fillPaints", []))
+
+    return fig_node.get("fillPaints", [])
 
 
 def convert_style_part_overrides(
-    sketch_path_str: str, paints: list, sketch_part: str
+    sketch_path_str: str, paints: list, sketch_part: str, master_part_paints: list
 ) -> Tuple[List[OverrideValue], List[str]]:
     sketch_overrides = []
     unsupported_overrides = []
 
     for index, paint in enumerate(paints):
         part_path = f"{sketch_part}-{index}"
+        master_paint = master_part_paints[index] if index < len(master_part_paints) else {}
 
         if "color" in paint:
             if paint.get("type") == "SOLID":
-                sketch_overrides.append(
-                    OverrideValue(
-                        overrideName=f"{sketch_path_str}_color:{part_path}",
-                        value=style_converter.convert_color(paint["color"]),
-                    )
+                color = style_converter.convert_color(paint["color"])
+                master_color = (
+                    style_converter.convert_color(master_paint["color"])
+                    if "color" in master_paint
+                    else None
                 )
+                if color != master_color:
+                    sketch_overrides.append(
+                        OverrideValue(
+                            overrideName=f"{sketch_path_str}_color:{part_path}",
+                            value=color,
+                        )
+                    )
             else:
                 unsupported_overrides.append("color")
 
-        if "blendMode" in paint:
+        blend_mode = style_converter.BLEND_MODE[paint.get("blendMode", "NORMAL")]
+        master_blend_mode = style_converter.BLEND_MODE[master_paint.get("blendMode", "NORMAL")]
+        if "blendMode" in paint and blend_mode != master_blend_mode:
             sketch_overrides.append(
                 OverrideValue(
                     overrideName=f"{sketch_path_str}_blendMode:{part_path}",
-                    value=style_converter.BLEND_MODE[paint.get("blendMode", "NORMAL")],
+                    value=blend_mode,
                 )
             )
 
-        if "opacity" in paint:
+        if "opacity" in paint and paint["opacity"] != master_paint.get("opacity", 1):
             sketch_overrides.append(
                 OverrideValue(
                     overrideName=f"{sketch_path_str}_opacity:{part_path}",

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -411,6 +411,13 @@ def convert_style_part_overrides(
 
 
 def unsupported_paint_override_props(paint: dict) -> List[str]:
+    """Return paint override fields that are unsafe to keep on an attached instance.
+
+    Properties listed below are supported or intentionally dropped becuase Sketch has no
+    equivalent override representation. Any remaining fields are reported as unsupported
+    so the instance can detach rather than silently losing data the converter does not
+    understand.
+    """
     ignored_props = {"blendMode", "color", "opacity", "type", "visible"}
     if paint.get("type") == "SOLID":
         return [prop for prop in paint if prop not in ignored_props]

--- a/src/converter/instance.py
+++ b/src/converter/instance.py
@@ -6,7 +6,7 @@ from converter import utils
 from sketchformat.layer_group import SymbolInstance, OverrideValue
 from sketchformat.style import Style
 from typing import List, Tuple
-from .errors import Fig2SketchNodeChanged
+from .errors import Fig2SketchNodeChanged, Fig2SketchWarning
 
 
 def convert(fig_instance):
@@ -208,6 +208,14 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             sk, us = convert_style_part_overrides(sketch_path_str, value, "border")
             sketch_overrides += sk
             unsupported_overrides += [f"strokePaints.{p}" for p in us]
+        elif prop == "styleIdForFill":
+            sk, us = convert_style_ref_override(sketch_path_str, value, "fill")
+            sketch_overrides += sk
+            unsupported_overrides += [f"styleIdForFill.{p}" for p in us]
+        elif prop == "styleIdForStroke":
+            sk, us = convert_style_ref_override(sketch_path_str, value, "border")
+            sketch_overrides += sk
+            unsupported_overrides += [f"styleIdForStroke.{p}" for p in us]
         elif prop in ["size", "pluginData", "name", "exportSettings", "targetAspectRatio"]:
             # Size is handled by applying derivedSymbolData
             # The rest are surely not worth detaching for
@@ -217,6 +225,20 @@ def convert_override(override: dict, fig_instance: dict) -> Tuple[List[OverrideV
             unsupported_overrides.append(prop)
 
     return sketch_overrides, unsupported_overrides
+
+
+def convert_style_ref_override(
+    sketch_path_str: str, style_ref: dict, sketch_part: str
+) -> Tuple[List[OverrideValue], List[str]]:
+    try:
+        fig_style = context.fig_node_by_key(style_ref["assetRef"]["key"])
+    except Fig2SketchWarning:
+        return [], ["assetRef"]
+
+    if "fillPaints" not in fig_style:
+        return [], ["fillPaints"]
+
+    return convert_style_part_overrides(sketch_path_str, fig_style["fillPaints"], sketch_part)
 
 
 def convert_style_part_overrides(

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -2,6 +2,7 @@ from .base import *
 import copy
 import pytest
 from converter import tree
+from converter import style as style_converter
 from converter.config import config
 from converter.context import context
 from sketchformat.layer_group import Group, SymbolInstance, OverrideValue, Frame
@@ -399,6 +400,114 @@ class TestOverrides:
                 overrideName=f"{symbol_rect_id}_blendMode:border-0", value=BlendMode.SCREEN
             ),
             OverrideValue(overrideName=f"{symbol_rect_id}_opacity:border-0", value=0.5),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_gradient_border_override(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(0, 2)]},
+                "strokePaints": [
+                    {
+                        "type": "GRADIENT_LINEAR",
+                        "transform": Matrix([[1, 0, 0], [0, 1, 0]]),
+                        "stops": [
+                            {"color": FIG_COLOR[0], "position": 0},
+                            {"color": FIG_COLOR[1], "position": 1},
+                        ],
+                        "opacity": 0.38,
+                        "blendMode": "NORMAL",
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_rect_id = symbol.layers[1].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(
+                overrideName=f"{symbol_rect_id}_color:border-0",
+                value=style_converter.convert_gradient(
+                    FIG_RECT, fig["symbolData"]["symbolOverrides"][0]["strokePaints"][0]
+                ),
+            ),
+            OverrideValue(overrideName=f"{symbol_rect_id}_opacity:border-0", value=0.38),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_matching_gradient_border_override_is_omitted(self, warnings):
+        rect = copy.deepcopy(FIG_RECT)
+        rect["strokePaints"] = [
+            {
+                "type": "GRADIENT_LINEAR",
+                "transform": Matrix([[1, 0, 0], [0, 1, 0]]),
+                "stops": [
+                    {"color": FIG_COLOR[0], "position": 0},
+                    {"color": FIG_COLOR[1], "position": 1},
+                ],
+                "opacity": 0.38,
+                "blendMode": "NORMAL",
+                "visible": True,
+            }
+        ]
+        symbol = {**copy.deepcopy(FIG_SYMBOL), "children": [FIG_TEXT, rect, FIG_VECTOR]}
+        context.init(
+            None,
+            {
+                (0, 3): symbol,
+                (0, 1): FIG_TEXT,
+                (0, 2): rect,
+                (0, 5): FIG_FILL_STYLE,
+                (0, 6): FIG_VECTOR,
+                (1, 9): FIG_TEXT,
+                (1, 10): FIG_VECTOR,
+            },
+            "DISPLAY_P3",
+        )
+        context._component_symbols = {(0, 3): False}
+
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {"guidPath": {"guids": [(0, 2)]}, "strokePaints": copy.deepcopy(rect["strokePaints"])}
+        ]
+
+        i = tree.convert_node(fig, "")
+
+        assert isinstance(i, SymbolInstance)
+        assert i.overrideValues == []
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_gradient_border_opacity_override_without_gradient_fields(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(0, 2)]},
+                "strokePaints": [
+                    {
+                        "type": "GRADIENT_LINEAR",
+                        "opacity": 0.38,
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_rect_id = symbol.layers[1].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_rect_id}_opacity:border-0", value=0.38),
         ]
         assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -340,6 +340,40 @@ class TestOverrides:
         )
         assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 
+    def test_detached_fill_style_override_with_paints(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 10)]},
+                "styleIdForFill": {"guid": [(2**32) - 1, (2**32) - 1]},
+                "fillPaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[1],
+                        "opacity": 0.7,
+                        "blendMode": "MULTIPLY",
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_vector_id = symbol.layers[2].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_vector_id}_color:fill-0", value=SKETCH_COLOR[1]),
+            OverrideValue(
+                overrideName=f"{symbol_vector_id}_blendMode:fill-0", value=BlendMode.MULTIPLY
+            ),
+            OverrideValue(overrideName=f"{symbol_vector_id}_opacity:fill-0", value=0.7),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
     def test_color_override_ignored(self, no_detach, warnings):
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -35,6 +35,23 @@ FIG_RECT = {
     "strokeWeight": 1,
 }
 
+FIG_FILL_STYLE = {
+    **FIG_BASE,
+    "type": "ROUNDED_RECTANGLE",
+    "guid": (0, 5),
+    "key": "red-fill",
+    "styleType": "FILL",
+    "fillPaints": [
+        {
+            "type": "SOLID",
+            "color": FIG_COLOR[1],
+            "opacity": 0.7,
+            "blendMode": "MULTIPLY",
+            "visible": True,
+        }
+    ],
+}
+
 FIG_SYMBOL = {
     **FIG_BASE,
     "type": "SYMBOL",
@@ -57,7 +74,13 @@ FIG_INSTANCE = {
 def symbol(monkeypatch):
     context.init(
         None,
-        {(0, 3): FIG_SYMBOL, (0, 1): FIG_TEXT, (0, 2): FIG_RECT, (1, 9): FIG_TEXT},
+        {
+            (0, 3): FIG_SYMBOL,
+            (0, 1): FIG_TEXT,
+            (0, 2): FIG_RECT,
+            (0, 5): FIG_FILL_STYLE,
+            (1, 9): FIG_TEXT,
+        },
         "DISPLAY_P3",
     )
     context._component_symbols = {(0, 3): False}
@@ -218,6 +241,31 @@ class TestOverrides:
                 overrideName=f"{symbol_rect_id}_blendMode:border-0", value=BlendMode.SCREEN
             ),
             OverrideValue(overrideName=f"{symbol_rect_id}_opacity:border-0", value=0.5),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_fill_style_override(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 9)]},
+                "styleIdForFill": {"assetRef": {"key": "red-fill", "version": "1:1"}},
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_text_id = symbol.layers[0].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_text_id}_color:fill-0", value=SKETCH_COLOR[1]),
+            OverrideValue(
+                overrideName=f"{symbol_text_id}_blendMode:fill-0", value=BlendMode.MULTIPLY
+            ),
+            OverrideValue(overrideName=f"{symbol_text_id}_opacity:fill-0", value=0.7),
         ]
         assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -294,6 +294,49 @@ class TestOverrides:
         ]
         assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 
+    def test_shadow_override(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(0, 2)]},
+                "effects": [
+                    {
+                        "type": "DROP_SHADOW",
+                        "offset": {"x": 3, "y": 6},
+                        "radius": 5,
+                        "spread": 2,
+                        "color": FIG_COLOR[1],
+                        "visible": True,
+                        "blendMode": "NORMAL",
+                    },
+                    {
+                        "type": "INNER_SHADOW",
+                        "offset": {"x": 1, "y": 2},
+                        "radius": 3,
+                        "spread": 4,
+                        "color": FIG_COLOR[2],
+                        "visible": True,
+                        "blendMode": "NORMAL",
+                    },
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_rect_id = symbol.layers[1].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_rect_id}_color:shadow-0", value=SKETCH_COLOR[1]),
+            OverrideValue(
+                overrideName=f"{symbol_rect_id}_color:innershadow-0", value=SKETCH_COLOR[2]
+            ),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
     def test_fill_style_override(self, warnings):
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -261,6 +261,114 @@ class TestOverrides:
         ]
         assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 
+    def test_fill_override_emits_default_opacity_when_master_differs(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 9)]},
+                "fillPaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[1],
+                        "opacity": 1,
+                        "blendMode": "NORMAL",
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_text_id = symbol.layers[0].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_text_id}_color:fill-0", value=SKETCH_COLOR[1]),
+            OverrideValue(overrideName=f"{symbol_text_id}_opacity:fill-0", value=1),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_fill_override_omits_values_matching_master(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 9)]},
+                "fillPaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[1],
+                        "opacity": 0.9,
+                        "blendMode": "NORMAL",
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_text_id = symbol.layers[0].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_text_id}_color:fill-0", value=SKETCH_COLOR[1])
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_fill_override_emits_normal_blend_when_master_differs(self, warnings):
+        text = copy.deepcopy(FIG_TEXT)
+        text["fillPaints"][0]["blendMode"] = "MULTIPLY"
+        symbol = {**copy.deepcopy(FIG_SYMBOL), "children": [text, FIG_RECT, FIG_VECTOR]}
+        context.init(
+            None,
+            {
+                (0, 3): symbol,
+                (0, 1): text,
+                (0, 2): FIG_RECT,
+                (0, 5): FIG_FILL_STYLE,
+                (0, 6): FIG_VECTOR,
+                (1, 9): text,
+                (1, 10): FIG_VECTOR,
+            },
+            "DISPLAY_P3",
+        )
+        context._component_symbols = {(0, 3): False}
+
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 9)]},
+                "fillPaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[0],
+                        "opacity": 0.9,
+                        "blendMode": "NORMAL",
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_text_id = symbol.layers[0].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(
+                overrideName=f"{symbol_text_id}_blendMode:fill-0", value=BlendMode.NORMAL
+            )
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
     def test_border_override(self, warnings):
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -52,11 +52,59 @@ FIG_FILL_STYLE = {
     ],
 }
 
+FIG_VECTOR = {
+    **FIG_BASE,
+    "type": "VECTOR",
+    "guid": (0, 6),
+    "overrideKey": (1, 10),
+    "cornerRadius": 0,
+    "fillPaints": [{"type": "SOLID", "color": FIG_COLOR[0], "opacity": 0.9, "visible": True}],
+    "vectorNetwork": {
+        "regions": [
+            {
+                "loops": [[0, 1, 2]],
+                "style": {
+                    "fillPaints": [
+                        {
+                            "type": "SOLID",
+                            "color": FIG_COLOR[0],
+                            "opacity": 0.9,
+                            "visible": True,
+                        }
+                    ]
+                },
+                "windingRule": "NONZERO",
+            }
+        ],
+        "segments": [
+            {
+                "start": 0,
+                "end": 1,
+                "tangentStart": {"x": 0, "y": 0},
+                "tangentEnd": {"x": 0, "y": 0},
+            },
+            {
+                "start": 1,
+                "end": 2,
+                "tangentStart": {"x": 0, "y": 0},
+                "tangentEnd": {"x": 0, "y": 0},
+            },
+            {
+                "start": 2,
+                "end": 0,
+                "tangentStart": {"x": 0, "y": 0},
+                "tangentEnd": {"x": 0, "y": 0},
+            },
+        ],
+        "vertices": [{"x": 0, "y": 0}, {"x": 10, "y": 0}, {"x": 0, "y": 10}],
+    },
+}
+
 FIG_SYMBOL = {
     **FIG_BASE,
     "type": "SYMBOL",
     "guid": (0, 3),
-    "children": [FIG_TEXT, FIG_RECT],
+    "children": [FIG_TEXT, FIG_RECT, FIG_VECTOR],
     "parent": {"guid": (0, 3)},
 }
 
@@ -79,7 +127,9 @@ def symbol(monkeypatch):
             (0, 1): FIG_TEXT,
             (0, 2): FIG_RECT,
             (0, 5): FIG_FILL_STYLE,
+            (0, 6): FIG_VECTOR,
             (1, 9): FIG_TEXT,
+            (1, 10): FIG_VECTOR,
         },
         "DISPLAY_P3",
     )
@@ -267,6 +317,27 @@ class TestOverrides:
             ),
             OverrideValue(overrideName=f"{symbol_text_id}_opacity:fill-0", value=0.7),
         ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_vector_fill_style_override_uses_shape_path_id(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(1, 10)]},
+                "styleIdForFill": {"assetRef": {"key": "red-fill", "version": "1:1"}},
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_vector_id = symbol.layers[2].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues[0] == OverrideValue(
+            overrideName=f"{symbol_vector_id}_color:fill-0", value=SKETCH_COLOR[1]
+        )
         assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 
     def test_color_override_ignored(self, no_detach, warnings):

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -27,7 +27,13 @@ FIG_TEXT = {
     ],
 }
 
-FIG_RECT = {**FIG_BASE, "type": "ROUNDED_RECTANGLE", "guid": (0, 2)}
+FIG_RECT = {
+    **FIG_BASE,
+    "type": "ROUNDED_RECTANGLE",
+    "guid": (0, 2),
+    "strokePaints": [{"type": "SOLID", "color": FIG_COLOR[0], "opacity": 0.9, "visible": True}],
+    "strokeWeight": 1,
+}
 
 FIG_SYMBOL = {
     **FIG_BASE,
@@ -124,7 +130,30 @@ class TestOverrides:
             OverrideValue(overrideName=f"{symbol_text_id}_stringValue", value="modified")
         ]
 
-    def test_color_override_detach(self, warnings):
+    def test_root_opacity_override_preserves_instance(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [{"guidPath": {"guids": [(0, 3)]}, "opacity": 0.7}]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.style.contextSettings.opacity == 0.7
+        assert i.overrideValues == []
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
+
+    def test_nested_opacity_override_detaches(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [{"guidPath": {"guids": [(1, 9)]}, "opacity": 0.7}]
+
+        i = tree.convert_node(fig, "")
+
+        assert isinstance(i, Group)
+        warnings.assert_any_call("SYM003", ANY, props=["opacity"])
+
+    def test_fill_override(self, warnings):
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [
             {
@@ -134,6 +163,7 @@ class TestOverrides:
                         "type": "SOLID",
                         "color": FIG_COLOR[1],
                         "opacity": 0.7,
+                        "blendMode": "MULTIPLY",
                         "visible": True,
                     }
                 ],
@@ -145,24 +175,56 @@ class TestOverrides:
         symbol = context.symbols_page.layers[0]
         symbol_text_id = symbol.layers[0].do_objectID
 
-        assert isinstance(i, Group)
-        assert i.layers[0].style.fills[0].color == SKETCH_COLOR[1]
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_text_id}_color:fill-0", value=SKETCH_COLOR[1]),
+            OverrideValue(
+                overrideName=f"{symbol_text_id}_blendMode:fill-0", value=BlendMode.MULTIPLY
+            ),
+            OverrideValue(overrideName=f"{symbol_text_id}_opacity:fill-0", value=0.7),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 
-        warnings.assert_any_call("SYM003", ANY, props=["fillPaints"])
+    def test_border_override(self, warnings):
+        fig = copy.deepcopy(FIG_INSTANCE)
+        fig["symbolData"]["symbolOverrides"] = [
+            {
+                "guidPath": {"guids": [(0, 2)]},
+                "strokePaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[1],
+                        "opacity": 0.5,
+                        "blendMode": "SCREEN",
+                        "visible": True,
+                    }
+                ],
+            }
+        ]
+
+        i = tree.convert_node(fig, "")
+        assert len(context.symbols_page.layers) == 1
+        symbol = context.symbols_page.layers[0]
+        symbol_rect_id = symbol.layers[1].do_objectID
+
+        assert isinstance(i, SymbolInstance)
+        assert i.symbolID == symbol.symbolID
+        assert i.overrideValues == [
+            OverrideValue(overrideName=f"{symbol_rect_id}_color:border-0", value=SKETCH_COLOR[1]),
+            OverrideValue(
+                overrideName=f"{symbol_rect_id}_blendMode:border-0", value=BlendMode.SCREEN
+            ),
+            OverrideValue(overrideName=f"{symbol_rect_id}_opacity:border-0", value=0.5),
+        ]
+        assert not any(call.args[0] == "SYM003" for call in warnings.call_args_list)
 
     def test_color_override_ignored(self, no_detach, warnings):
         fig = copy.deepcopy(FIG_INSTANCE)
         fig["symbolData"]["symbolOverrides"] = [
             {
                 "guidPath": {"guids": [(0, 1)]},
-                "fillPaints": [
-                    {
-                        "type": "SOLID",
-                        "color": FIG_COLOR[1],
-                        "opacity": 0.7,
-                        "visible": True,
-                    }
-                ],
+                "fontSize": 16,
             }
         ]
 
@@ -174,7 +236,7 @@ class TestOverrides:
         assert i.symbolID == symbol.symbolID
         assert i.overrideValues == []
 
-        warnings.assert_any_call("SYM002", ANY, props=["fillPaints"])
+        warnings.assert_any_call("SYM002", ANY, props=["fontSize"])
 
     def test_prop_and_symbol_override(self):
         """When a property and an override are specified for the same thing, we want
@@ -207,7 +269,7 @@ class TestDetach:
         fig["symbolData"]["symbolOverrides"] = [
             {
                 "guidPath": {"guids": [(1, 9)]},
-                "fillPaints": [],
+                "opacity": 0.5,
             }
         ]
         fig["resizeToFit"] = True
@@ -220,7 +282,7 @@ class TestDetach:
         fig["symbolData"]["symbolOverrides"] = [
             {
                 "guidPath": {"guids": [(1, 9)]},
-                "fillPaints": [],
+                "opacity": 0.5,
             }
         ]
         fig["resizeToFit"] = False

--- a/tests/converter/test_instance.py
+++ b/tests/converter/test_instance.py
@@ -132,7 +132,9 @@ class TestOverrides:
 
     def test_root_opacity_override_preserves_instance(self, warnings):
         fig = copy.deepcopy(FIG_INSTANCE)
-        fig["symbolData"]["symbolOverrides"] = [{"guidPath": {"guids": [(0, 3)]}, "opacity": 0.7}]
+        fig["symbolData"]["symbolOverrides"] = [
+            {"guidPath": {"guids": [(0, 3)]}, "opacity": 0.7, "targetAspectRatio": {}}
+        ]
 
         i = tree.convert_node(fig, "")
         assert len(context.symbols_page.layers) == 1

--- a/tests/integration/test_structure.py
+++ b/tests/integration/test_structure.py
@@ -173,17 +173,7 @@ def test_page(sketch_doc):
                     "green": 0.0,
                     "red": 1.0,
                 },
-            },
-            {
-                "_class": "overrideValue",
-                "overrideName": "82E52E33-0F1A-4CEA-8D95-0BFD55F9CEE3_blendMode:fill-0",
-                "value": 0,
-            },
-            {
-                "_class": "overrideValue",
-                "overrideName": "82E52E33-0F1A-4CEA-8D95-0BFD55F9CEE3_opacity:fill-0",
-                "value": 1.0,
-            },
+            }
         ]
 
         # JPG image

--- a/tests/integration/test_structure.py
+++ b/tests/integration/test_structure.py
@@ -159,17 +159,32 @@ def test_page(sketch_doc):
             }
         ]
 
-        # Instance with color override (detached)
-        assert i3["_class"] == "group"
-        assert len(i3["layers"]) == 2
-        assert i3["layers"][0]["_class"] == "rectangle"
-        assert i3["layers"][0]["style"]["fills"][0]["color"] == {
-            "_class": "color",
-            "alpha": 1.0,
-            "blue": 0.0,
-            "green": 0.0,
-            "red": 1.0,
-        }
+        # Instance with color override
+        assert i3["_class"] == "symbolInstance"
+        assert "layers" not in i3
+        assert i3["overrideValues"] == [
+            {
+                "_class": "overrideValue",
+                "overrideName": "82E52E33-0F1A-4CEA-8D95-0BFD55F9CEE3_color:fill-0",
+                "value": {
+                    "_class": "color",
+                    "alpha": 1.0,
+                    "blue": 0.0,
+                    "green": 0.0,
+                    "red": 1.0,
+                },
+            },
+            {
+                "_class": "overrideValue",
+                "overrideName": "82E52E33-0F1A-4CEA-8D95-0BFD55F9CEE3_blendMode:fill-0",
+                "value": 0,
+            },
+            {
+                "_class": "overrideValue",
+                "overrideName": "82E52E33-0F1A-4CEA-8D95-0BFD55F9CEE3_opacity:fill-0",
+                "value": 1.0,
+            },
+        ]
 
         # JPG image
         assert jpg["_class"] == "rectangle"


### PR DESCRIPTION
## Summary
- keep symbol instances attached when supported opacity and style overrides are present
- convert fill and border paint overrides into Sketch override values
- resolve Figma fill style references and local detached fill colors
- target converted vector shape path IDs when building override paths