### PR TITLE
Fix text imports setting fill color for single text color

### DIFF
--- a/src/converter/text.py
+++ b/src/converter/text.py
@@ -87,10 +87,7 @@ def convert(fig_text):
     obj.resizingConstraint &= CONSTRAINT_MASK_FOR_AUTO_RESIZE[text_resize]
 
     obj.style.textStyle = text_style(fig_text)
-
-    # Potentially multiple colors, use the attributes instead of the top level color
-    if len(obj.attributedString.attributes) > 1:
-        obj.style.fills = []
+    reconcile_text_and_fill_colors(obj)
 
     # Adjust frame's width to include kerning so the text doesn't get cut
     converted_kerning = obj.style.textStyle.encodedAttributes.kerning
@@ -98,6 +95,28 @@ def convert(fig_text):
         obj.frame.width += converted_kerning
 
     return obj
+
+
+def reconcile_text_and_fill_colors(obj: Text) -> None:
+    text_colors = []
+    for attr in obj.attributedString.attributes:
+        color = attr.attributes.MSAttributedStringColorAttribute
+        if color not in text_colors:
+            text_colors.append(color)
+
+    if len(text_colors) > 1:
+        obj.style.fills = []
+        return
+
+    text_color = text_colors[0]
+    if len(obj.style.fills) == 1 and obj.style.fills[0].color == text_color:
+        obj.style.fills = []
+        return
+
+    if len(obj.style.fills) > 1:
+        obj.style.textStyle.encodedAttributes.MSAttributedStringColorAttribute = Color.Black()
+        for attr in obj.attributedString.attributes:
+            attr.attributes.MSAttributedStringColorAttribute = Color.Black()
 
 
 def text_style(fig_text):

--- a/tests/converter/test_text.py
+++ b/tests/converter/test_text.py
@@ -1,7 +1,10 @@
+import dataclasses
+
 import pytest
 from .base import *
 from converter.text import *
 from converter.context import context
+from sketchformat.serialize.json import convert_object
 
 TEXT_BASE = {
     **FIG_BASE,
@@ -144,6 +147,99 @@ class TestOverrideStyles:
 
 @pytest.mark.usefixtures("mock_fonts")
 class TestConvert:
+    def test_matching_single_text_and_fill_color_removes_fill(self):
+        text = convert(
+            {
+                **TEXT_PLAIN,
+                "fillPaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[0],
+                        "opacity": FIG_COLOR[0]["a"],
+                        "visible": True,
+                    },
+                ],
+            }
+        )
+        serialized_text = convert_object(text)
+
+        assert text.style.fills == []
+        assert serialized_text["style"]["fills"] == []
+        assert (
+            text.style.textStyle.encodedAttributes.MSAttributedStringColorAttribute
+            == SKETCH_COLOR[0]
+        )
+        assert (
+            text.attributedString.attributes[0].attributes.MSAttributedStringColorAttribute
+            == SKETCH_COLOR[0]
+        )
+        assert (
+            serialized_text["style"]["textStyle"]["encodedAttributes"][
+                "MSAttributedStringColorAttribute"
+            ]
+            == convert_object(SKETCH_COLOR[0])
+        )
+
+    def test_multi_color_text_removes_all_fills(self):
+        text = convert(
+            {
+                **TEXT_BASE,
+                "textData": {
+                    "characters": "abc",
+                    "characterStyleIDs": [0, 1, 1],
+                    "styleOverrideTable": [
+                        {
+                            "styleID": 1,
+                            "fillPaints": [{"type": "SOLID", "color": FIG_COLOR[1]}],
+                        },
+                    ],
+                },
+            }
+        )
+
+        assert text.style.fills == []
+        assert (
+            text.attributedString.attributes[0].attributes.MSAttributedStringColorAttribute
+            == SKETCH_COLOR[0]
+        )
+        assert (
+            text.attributedString.attributes[1].attributes.MSAttributedStringColorAttribute
+            == SKETCH_COLOR[1]
+        )
+
+    def test_multiple_fill_colors_with_one_text_color_keeps_fills_and_sets_text_black(self):
+        text = convert(
+            {
+                **TEXT_PLAIN,
+                "fillPaints": [
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[0],
+                        "opacity": 1,
+                        "visible": True,
+                    },
+                    {
+                        "type": "SOLID",
+                        "color": FIG_COLOR[1],
+                        "opacity": 1,
+                        "visible": True,
+                    },
+                ],
+            }
+        )
+
+        assert len(text.style.fills) == 2
+        assert text.style.fills[0].color == dataclasses.replace(SKETCH_COLOR[0], alpha=1)
+        assert text.style.fills[1].color == dataclasses.replace(SKETCH_COLOR[1], alpha=1)
+        assert (
+            text.style.textStyle.encodedAttributes.MSAttributedStringColorAttribute
+            == Color.Black()
+        )
+        assert (
+            text.attributedString.attributes[0].attributes.MSAttributedStringColorAttribute
+            == Color.Black()
+        )
+
     def test_no_kerning(self):
         text = convert(TEXT_PLAIN)
 


### PR DESCRIPTION
## Summary
- Reconcile Figma text colors and Sketch layer fills using the MAC-9452 rules.
- Remove all layer fills for multicolor text because the colors belong in attributed text runs.
- Remove a single layer fill only when its converted Sketch color exactly matches the single text color.
- Keep multiple layer fills, but set the single text color to black so Sketch uses the fill stack for rendering.

## Root Cause
Single-color Figma text layers could be converted into both a text color attribute and a Sketch layer fill. The original fix removed fills too broadly; text with multiple fills needs to preserve the fill stack and use black text as the mask color.

## Validation
- `.venv/bin/pytest` -> 199 passed
- Converted `/Users/jpedroso/Downloads/text_colors.fig` with `--salt=1234` and inspected the generated Sketch JSON for the three sample scenarios.